### PR TITLE
Add support for sawtooth client library

### DIFF
--- a/libs/base/include/suil/base/syson.hpp
+++ b/libs/base/include/suil/base/syson.hpp
@@ -6,7 +6,7 @@
 
 #include <suil/base/signal.hpp>
 
-#include <signal.h>
+#include <csignal>
 #include <mutex>
 
 namespace suil {

--- a/libs/network/src/zmq/socket.cpp
+++ b/libs/network/src/zmq/socket.cpp
@@ -80,7 +80,7 @@ namespace suil::net::zmq {
             if (_id.empty()) {
                 _id = suil::randbytes(16);
                 Option::setIdentity(Ego, _id);
-                idebug("Created socket identity %s", _id());
+                itrace("Created socket identity %s", _id());
             }
         }
     }

--- a/libs/sawtooth/CMakeLists.txt
+++ b/libs/sawtooth/CMakeLists.txt
@@ -77,7 +77,7 @@ if (ENABLE_UNIT_TESTS)
     include_directories(test)
     include(SuilUnitTest)
     SuilUnitTest(Sawtooth-UnitTest
-            SOURCES ${SUIL_SAWTOOTH_SOURCES} test/main.cpp
+            SOURCES test/main.cpp
             LIBS    Suil::HttpClient)
     set_target_properties(Sawtooth-UnitTest
         PROPERTIES

--- a/libs/sawtooth/CMakeLists.txt
+++ b/libs/sawtooth/CMakeLists.txt
@@ -1,0 +1,87 @@
+cmake_minimum_required(VERSION 3.10)
+# The version of the library, configurable from command line
+set(SUIL_SAWTOOTH_VERSION "0.1.0" CACHE STRING "The version of suil-sawtooth library")
+
+project(Sawtooth VERSION ${SUIL_SAWTOOTH_VERSION} LANGUAGES C CXX)
+
+include(protos/Protos.cmake)
+
+set(SUIL_SAWTOOTH_SOURCES
+        ${SAWTOOTH_PROTO_SRCS}
+        src/address.cpp
+        src/client.cpp
+        src/dispatcher.cpp
+        src/events.cpp
+        src/gstate.cpp
+        src/message.cpp
+        src/processor.cpp
+        src/rest.cpp
+        src/stream.cpp
+        src/tp.cpp
+        src/transaction.cpp
+        src/wallet.cpp
+        ${CMAKE_BINARY_DIR}/scc/public/suil/sawtooth/sawtooth.scc.cpp)
+
+add_library(Sawtooth STATIC
+    ${SUIL_SAWTOOTH_SOURCES})
+add_library(Suil::Sawtooth ALIAS Sawtooth)
+set_target_properties(Sawtooth
+    PROPERTIES
+        OUTPUT_NAME SuilSawtooth)
+
+target_link_libraries(Sawtooth
+        PUBLIC Suil::HttpClient protobuf::libprotobuf)
+
+target_include_directories(Sawtooth PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
+target_include_directories(Sawtooth PRIVATE
+        ${CMAKE_BINARY_DIR}/scc/public)
+
+add_executable(Sawtooth-Wallet
+        src/stw/main.cpp
+        src/stw/stw.cpp)
+target_link_libraries(Sawtooth-Wallet Suil::Sawtooth)
+
+set_target_properties(Sawtooth-Wallet
+        PROPERTIES
+        RUNTIME_OUTPUT_NAME stw)
+
+set(SUIL_SAWTOOTH_SCC_SOURCES
+        scc/sawtooth.scc)
+
+SuilScc(Sawtooth
+        SOURCES  ${SUIL_SAWTOOTH_SCC_SOURCES}
+        LIB_PATH ${CMAKE_BINARY_DIR}
+        OUTDIR   ${CMAKE_BINARY_DIR}/scc/public/suil/sawtooth)
+add_dependencies(Sawtooth-scc Base-Generator)
+
+target_include_directories(Sawtooth-Wallet PRIVATE
+        ${CMAKE_BINARY_DIR}/scc/public)
+
+# Install base library
+install(TARGETS Sawtooth Sawtooth-Wallet
+        EXPORT  ${TARGETS_EXPORT_NAME}
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
+
+# Install includes library
+install(DIRECTORY include/suil/sawtooth/
+        DESTINATION include/suil/sawtooth
+        FILES_MATCHING PATTERN "*.hpp")
+install(DIRECTORY ${CMAKE_BINARY_DIR}/scc/public/suil/sawtooth/
+        DESTINATION include/suil/sawtooth
+        FILES_MATCHING PATTERN "*.hpp")
+
+if (ENABLE_UNIT_TESTS)
+    include_directories(test)
+    include(SuilUnitTest)
+    SuilUnitTest(Sawtooth-UnitTest
+            SOURCES ${SUIL_SAWTOOTH_SOURCES} test/main.cpp
+            LIBS    Suil::HttpClient)
+    set_target_properties(Sawtooth-UnitTest
+        PROPERTIES
+            RUNTIME_OUTPUT_NAME sawtooth_unittest)
+endif()
+
+include(example/Examples.cmake)

--- a/libs/sawtooth/example/Examples.cmake
+++ b/libs/sawtooth/example/Examples.cmake
@@ -1,0 +1,24 @@
+  if (ENABLE_EXAMPLES)
+      add_executable(Sawtooth-IntKey
+              ${CMAKE_CURRENT_SOURCE_DIR}/example/intkey/tp.cpp
+              ${CMAKE_CURRENT_SOURCE_DIR}/example/intkey/main.cpp)
+      set_target_properties(Sawtooth-IntKey
+              PROPERTIES
+              RUNTIME_OUTPUT_NAME sawtooth-intkey)
+      target_link_libraries(Sawtooth-IntKey
+              PRIVATE Suil::Sawtooth)
+      target_include_directories(Sawtooth-IntKey
+              PRIVATE ${CMAKE_BINARY_DIR}/scc/public)
+
+
+      add_executable(Sawtooth-IntKey-Cli
+              ${CMAKE_CURRENT_SOURCE_DIR}/example/intkey/cli/app.cpp
+              ${CMAKE_CURRENT_SOURCE_DIR}/example/intkey/cli/main.cpp)
+      set_target_properties(Sawtooth-IntKey-Cli
+              PROPERTIES
+              RUNTIME_OUTPUT_NAME sawtooth-intkey-cli)
+      target_link_libraries(Sawtooth-IntKey-Cli
+              PRIVATE Suil::Sawtooth)
+      target_include_directories(Sawtooth-IntKey-Cli
+              PRIVATE ${CMAKE_BINARY_DIR}/scc/public)
+  endif()

--- a/libs/sawtooth/example/intkey/cli/app.cpp
+++ b/libs/sawtooth/example/intkey/cli/app.cpp
@@ -1,0 +1,149 @@
+//
+// Created by Mpho Mbotho on 2021-06-22.
+//
+
+#include "app.hpp"
+#include <suil/sawtooth/transaction.hpp>
+
+namespace suil::saw {
+
+    App::App(args::Command& cmd)
+        : Client::RestApi(
+                cmd.value("url", "http://rest-api"_str),
+                "int-key",
+                "1.0",
+                cmd.value("key", "2c5683d43573214fa939d2df4ac0767fe3500b6eacbafa11cf8b8aeca8db9d60"_str),
+                cmd.value<int32_t>("port", 8008)
+                ),
+           mCmd{cmd}
+    {}
+
+    void App::modify(const String& verb)
+    {
+        auto name = mCmd.at<String>(0,
+                                    "Missing key name - usage: intkey-cli set|dec|inc [...] name value");
+        auto value = mCmd.at<int32>(1,
+                                    "Missing key value - usage: intkey-cli set|dec|inc [...] name value");
+        auto wait  = Ego.mCmd.value<uint64>("wait", 0) * 1000;
+
+        json::Object obj(json::Obj,
+                 "Verb", verb,
+                 "Name", name,
+                 "Value", value);
+        auto str = json::encode(obj);
+        auto prefix = Ego.getPrefix();
+
+        auto ret = Ego.asyncBatches(fromStdString(str), {prefix}, {prefix});
+        postSubmit(ret, wait);
+
+    }
+
+    void App::get()
+    {
+        auto name = mCmd.at<String>(0, "Missing key name - usage: intkey-cli get [...] endpoint name");
+        auto ret = Ego.getState(name);
+        if (!ret) {
+            serror("failed to retrieve key state - %s", ret.exception().what());
+            return;
+        }
+
+        auto state = ret.moveValue();
+        if (!state.empty()) {
+            auto obj = json::Object::decode(state);
+            auto value = (int32_t) obj(name());
+            sinfo(PRIs " = %d", _PRIs(name), value);
+        }
+    }
+
+    void App::list()
+    {
+        auto ret = Ego.getStates(Ego.getPrefix());
+        if (!ret) {
+            serror("failed to retrieve keys - %s", ret.exception().what());
+            return;
+        }
+
+        auto states = ret.moveValue();
+        for (auto& state: states) {
+            auto obj = json::Object::decode(state);
+            for (auto& [key, val] : obj) {
+                auto num = (int) val;
+                sinfo("%s = %d", key, num);
+            }
+        }
+    }
+
+    void App::batch()
+    {
+        auto count = Ego.mCmd.value<uint32>("count", 10);
+        auto wait  = Ego.mCmd.value<uint64>("wait", 0) * 1000;
+        auto& Enc = Ego.encoder();
+        auto prefix = Ego.getPrefix();
+        std::vector<Client::Transaction> txns;
+        for (int i = 0; i < count; i++) {
+            json::Object jobj(json::Obj,
+                              "Verb",  "set",
+                              "Name",  suil::catstr("Key",i),
+                              "Value", 100+i);
+            auto str = json::encode(jobj);
+            txns.push_back(Enc(fromStdString(str), {prefix}, {prefix}));
+        }
+
+        auto batch = Enc(txns);
+        auto ret = Ego.asyncBatches({batch});
+        postSubmit(ret, wait);
+    }
+
+    void App::postSubmit(const Return<String>& ret, uint64 wait)
+    {
+        if (!ret) {
+            serror("failed to submit batch - %s", ret.exception().message().c_str());
+            return;
+        }
+
+        if (wait == 0) {
+            sinfo("Create batch integer keys submitted {batch_id = " PRIs "}", _PRIs(ret.value()));
+            return;
+        }
+
+        if (!Ego.waitForStatus(ret.value(), wait, [&](auto& s) { return s != "PENDING"; } )) {
+            serror("Timeout waiting for batch to be committed {batch_id = " PRIs "}", _PRIs(ret.value()));
+        }
+    }
+
+    void App::cmdSet(args::Command& cmd)
+    {
+        App app(cmd);
+        app.modify("set");
+    }
+
+    void App::cmdGet(args::Command& cmd)
+    {
+        App app(cmd);
+        app.get();
+    }
+
+    void App::cmdBatch(args::Command& cmd)
+    {
+        App app(cmd);
+        app.batch();
+    }
+
+    void App::cmdDecrement(args::Command& cmd)
+    {
+        App app(cmd);
+        app.modify("dec");
+    }
+
+    void App::cmdIncrement(args::Command& cmd)
+    {
+        App app(cmd);
+        app.modify("inc");
+    }
+
+    void App::cmdList(args::Command& cmd)
+    {
+        App app(cmd);
+        app.list();
+    }
+}

--- a/libs/sawtooth/example/intkey/cli/app.hpp
+++ b/libs/sawtooth/example/intkey/cli/app.hpp
@@ -1,0 +1,36 @@
+//
+// Created by Mpho Mbotho on 2021-06-22.
+//
+
+#pragma once
+
+#include <suil/base/args.hpp>
+#include <suil/sawtooth/rest.hpp>
+#include <suil/sawtooth/events.hpp>
+
+namespace suil::saw {
+
+    class App : public Client::RestApi {
+    public:
+        DISABLE_COPY(App);
+        DISABLE_MOVE(App);
+
+        App(args::Command& cmd);
+
+        static void cmdSet(args::Command& cmd);
+        static void cmdGet(args::Command& cmd);
+        static void cmdIncrement(args::Command& cmd);
+        static void cmdDecrement(args::Command& cmd);
+        static void cmdList(args::Command& cmd);
+        static void cmdBatch(args::Command& cmd);
+
+    private:
+        void postSubmit(const Return<String>& ret, uint64 wait);
+        void modify(const String& verb);
+        void get();
+        void batch();
+        void list();
+
+        args::Command& mCmd;
+    };
+}

--- a/libs/sawtooth/example/intkey/cli/main.cpp
+++ b/libs/sawtooth/example/intkey/cli/main.cpp
@@ -1,0 +1,58 @@
+//
+// Created by Mpho Mbotho on 2021-06-22.
+//
+
+#include "app.hpp"
+
+
+using suil::args::Arguments;
+using suil::args::Command;
+using suil::args::Arg;
+using suil::args::Parser;
+using suil::Exception;
+
+using suil::saw::App;
+
+int main(int argc, char *argv[])
+{
+    Parser parser("intkey-cli", "1.0", "Application used to interact with int-key transaction processor");
+    try {
+        parser(
+            Arg{"url", "The address of sawtooth rest api endpoint", 'H', false},
+            Arg{"port", "The port on which sawtooth rest api endpoint is listening", 'P', false},
+            Arg{"key", "The private key used to sign the transactions", 'K', false},
+            Command("set", "Create a new integer key with the given name and value")
+                ({"wait", "The number of seconds to wait for batch to be committed (default: 0)", 'W', false})
+                (App::cmdSet)
+                (),
+            Command("inc", "Increment the given key with the given value")
+                ({"wait", "The number of seconds to wait for batch to be committed (default: 0)", 'W', false})
+                (App::cmdIncrement)
+                (),
+            Command("dec", "Decrement the given key with the given value")
+                ({"wait", "The number of seconds to wait for batch to be committed (default: 0)", 'W', false})
+                (App::cmdDecrement)
+                (),
+            Command("get", "Get the value associated with the given keys")
+                (App::cmdGet)
+                (),
+            Command("list", "List all key created for int-key transaction processor")
+                (App::cmdList)
+                (),
+            Command("batch", "Generate and set integer keys on int-key as a batch")
+                ({"count", "The number of integer keys to generate (default: 10)", 'C', false})
+                ({"wait", "The number of seconds to wait for batch to be committed (default: 0)", 'W', false})
+                (App::cmdBatch)
+                ()
+        );
+
+        parser.parse(argc, argv);
+        parser.handle();
+
+        return EXIT_SUCCESS;
+    }
+    catch(...) {
+        serror("unhandled error %s", Exception::fromCurrent().what());
+        return EXIT_FAILURE;
+    }
+}

--- a/libs/sawtooth/example/intkey/main.cpp
+++ b/libs/sawtooth/example/intkey/main.cpp
@@ -1,0 +1,56 @@
+//
+// Created by Mpho Mbotho on 2021-06-16.
+//
+
+#include "tp.hpp"
+
+#include <suil/base/args.hpp>
+#include <suil/sawtooth/tp.hpp>
+
+#define VALIDATOR_ENDPOINT "tcp://validator:4004"
+
+using suil::Exception;
+using suil::String;
+using suil::args::Arguments;
+using suil::args::Command;
+using suil::args::Parser;
+using suil::saw::TransactionProcessor;
+using suil::saw::IntKeyHandler;
+
+static void start(Command& cmd);
+
+int main(int argc, char* argv[])
+{
+    Parser parser("int-key", "1.0", "Integer key sawtooth transaction processor");
+    try {
+        parser(
+            Command("start", "Start running integer key transaction processor")
+                ({"endpoint", "The address of the validator to connect to", 'C', false})
+                (start)
+                ()
+        );
+        parser.parse(argc, argv);
+        parser.handle();
+    }
+    catch (...) {
+        auto ex = Exception::fromCurrent();
+        serror("unhandled error: %s", ex.what());
+        return EXIT_FAILURE;
+    }
+}
+
+void start(Command& cmd)
+{
+    constexpr const char * INTKEY_NAMESPACE = "int-key";
+    auto config = cmd.value("endpoint", String{VALIDATOR_ENDPOINT}).dup();
+    try {
+        TransactionProcessor processor(std::move(config));
+        auto& handler = processor.registerHandler<IntKeyHandler>(INTKEY_NAMESPACE, INTKEY_NAMESPACE);
+        handler.getVersions().emplace_back("1.0");
+        processor.run();
+    }
+    catch (...) {
+        auto ex = Exception::fromCurrent();
+        serror("%s", ex.what());
+    }
+}

--- a/libs/sawtooth/example/intkey/tp.cpp
+++ b/libs/sawtooth/example/intkey/tp.cpp
@@ -1,0 +1,131 @@
+//
+// Created by Mpho Mbotho on 2021-06-16.
+//
+
+#include "tp.hpp"
+
+#include <suil/base/json.hpp>
+
+namespace suil::saw {
+
+    UnorderedMap<IntKeyProcessor::VerbHandler> IntKeyProcessor::sHandlers = {
+        {"set", &IntKeyProcessor::setKey},
+        {"dec", &IntKeyProcessor::decrementKey},
+        {"inc", &IntKeyProcessor::incrementKey}
+    };
+
+    void IntKeyProcessor::apply()
+    {
+        auto& txn = Ego.getTransaction();
+        idebug("applying transaction");
+
+        auto obj = json::Object::decode(txn.payload());
+
+        auto verb = getString("Verb", obj);
+        auto handler = sHandlers.find(verb);
+        if (handler == sHandlers.end()) {
+            throw InvalidTransaction("'", verb, "' is not a supported verb");
+        }
+
+        (this->* handler->second)(obj);
+    }
+
+    String IntKeyProcessor::getString(const String& name, json::Object& obj)
+    {
+        auto value = (String) obj.get(name, false);
+        if (value.empty()) {
+            throw InvalidTransaction(name, " required");
+        }
+        return value;
+    }
+
+    std::uint32_t IntKeyProcessor::getNumber(const String& name, json::Object& obj)
+    {
+        auto value = obj.get(name, false);
+        if (!value) {
+            throw InvalidTransaction(name, " required");
+        }
+
+        return (std::uint32_t) value;
+    }
+
+    void IntKeyProcessor::setKey(json::Object& obj)
+    {
+        auto name = getString("Name", obj);
+        auto value = getNumber("Value", obj);
+        auto addr = mAe(name);
+        idebug("setKey {name: " PRIs ", value: %u}", _PRIs(name), value);
+
+        auto state = Ego.globalState().getState(addr);
+        json::Object current;
+        if (!state.empty()) {
+            current = json::Object::decode(state);
+            auto stateValue = current.get(name, false);
+            if (stateValue) {
+                throw InvalidTransaction(
+                        "Invalid 'Set' arguments, already exists {name: ",
+                        name, ", value: ", (std::uint32_t) stateValue, "}");
+            }
+        }
+        else {
+            current = json::Object(json::Obj, name(), value);
+        }
+        auto str = json::encode(current);
+        Ego.globalState().setState(addr, fromStdString(str));
+    }
+
+    void IntKeyProcessor::decrementKey(json::Object& obj)
+    {
+        auto name = getString("Name", obj);
+        auto value = getNumber("Value", obj);
+        auto addr = mAe(name);
+        idebug("decrementKey {name: " PRIs ", value: %u}", _PRIs(name), value);
+
+        json::Object current;
+        auto state = Ego.globalState().getState(addr);
+        if (state.empty()) {
+           throw InvalidTransaction("Failed to decrement, '", name, "' does not have a state");
+        }
+
+        current = json::Object::decode(state);
+        if (!current.get(name, false)) {
+            throw InvalidTransaction("Failed to decrement, '", name, "' does not exist in state");
+        }
+
+        auto stateValue = Ego.getNumber(name, current);
+        stateValue -= value;
+        current = json::Object(json::Obj, name(), stateValue);
+        auto str = json::encode(current);
+        Ego.globalState().setState(addr, fromStdString(str));
+    }
+
+    void IntKeyProcessor::incrementKey(json::Object& obj)
+    {
+        auto name = getString("Name", obj);
+        auto value = getNumber("Value", obj);
+        auto addr = mAe(name);
+        idebug("incrementKey {name: " PRIs ", value: %u}", _PRIs(name), value);
+
+        json::Object current;
+        auto state = Ego.globalState().getState(addr);
+        if (state.empty()) {
+            throw InvalidTransaction("Failed to increment, '", name, "' does not have a state");
+        }
+
+        current = json::Object::decode(state);
+        if (!current.get(name, false)) {
+            throw InvalidTransaction("Failed to increment, '", name, "' does not exist in state");
+        }
+
+        auto stateValue = Ego.getNumber(name, current);
+        stateValue += value;
+        current = json::Object(json::Obj, name(), stateValue);
+        auto str = json::encode(current);
+        Ego.globalState().setState(addr, fromStdString(str));
+    }
+
+    typename ProcessorBase::Ptr IntKeyHandler::getProcessor(Transaction&& txn, GlobalState&& state)
+    {
+        return std::make_shared<IntKeyProcessor>(addressEncoder(), std::move(txn), std::move(state));
+    }
+}

--- a/libs/sawtooth/example/intkey/tp.hpp
+++ b/libs/sawtooth/example/intkey/tp.hpp
@@ -1,0 +1,44 @@
+//
+// Created by Mpho Mbotho on 2021-06-16.
+//
+
+#pragma once
+
+#include <suil/sawtooth/processor.hpp>
+#include <suil/base/json.hpp>
+
+namespace suil::saw {
+
+    define_log_tag(SAW_INTKEY);
+
+    class IntKeyProcessor : public Processor<DefaultAddressEncoder> , LOGGER(SAW_INTKEY) {
+    public:
+        IntKeyProcessor(DefaultAddressEncoder& ae, Transaction&& txn, GlobalState&& state)
+            : Processor(ae),
+              ProcessorBase(std::move(txn), std::move(state))
+        {}
+
+        void apply() override;
+
+    private:
+        typedef void (IntKeyProcessor::*VerbHandler)(json::Object& obj);
+        void setKey(json::Object& obj);
+        void decrementKey(json::Object& obj);
+        void incrementKey(json::Object& obj);
+
+        String getString(const String& name, json::Object& obj);
+        std::uint32_t getNumber(const String& name, json::Object& obj);
+        static UnorderedMap<VerbHandler> sHandlers;
+    };
+
+    class IntKeyHandler : public TransactionHandler<> {
+    public:
+        static constexpr uint32 MAX_OCCUPANCY{127};
+        IntKeyHandler(const String& family, const String& ns)
+            : TransactionHandler(ns),
+              TransactionHandlerBase(family, MAX_OCCUPANCY)
+        {}
+
+        typename ProcessorBase::Ptr getProcessor(Transaction&& txn, GlobalState&& state) override;
+    };
+}

--- a/libs/sawtooth/include/suil/sawtooth/address.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/address.hpp
@@ -1,0 +1,43 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/base/exception.hpp>
+#include <suil/base/string.hpp>
+
+
+namespace suil::saw {
+
+    DECLARE_EXCEPTION(AddressEncodeError);
+
+    class DefaultAddressEncoder final {
+    public:
+        static constexpr size_t ADDRESS_LENGTH = 70;
+        static constexpr size_t NS_PREFIX_LENGTH = 6;
+
+        DefaultAddressEncoder(const String& ns);
+        DefaultAddressEncoder(DefaultAddressEncoder&& other) noexcept ;
+        DefaultAddressEncoder&operator=(DefaultAddressEncoder&& other) noexcept ;
+
+        DefaultAddressEncoder(const DefaultAddressEncoder&) = delete;
+        DefaultAddressEncoder&operator=(const DefaultAddressEncoder&) = delete;
+
+        String operator()(const String& key);
+        const String& getPrefix();
+
+        static void isValidAddr(const String& addr);
+
+        static void isNamespaceValid(const String& ns);
+    private:
+        String mapNamespace(const String& key) const;
+        String mapKey(const String& key);
+
+    private:
+        String mNamespace{};
+        String mPrefix{};
+    };
+
+}
+

--- a/libs/sawtooth/include/suil/sawtooth/client.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/client.hpp
@@ -1,0 +1,114 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/base/logging.hpp>
+#include <suil/base/secp256k1.hpp>
+#include <suil/sawtooth/protos.hpp>
+
+namespace suil::saw::Client {
+
+    DECLARE_EXCEPTION(EncoderError);
+
+    define_log_tag(SAWSDK_CLIENT);
+    class Signer final : LOGGER(SAWSDK_CLIENT) {
+    public:
+        Signer(Signer&& other) noexcept;
+        Signer& operator=(Signer&& other) noexcept;
+
+        Signer(const Signer&) = delete;
+        Signer& operator=(const Signer&) = delete;
+
+        static Signer load(const suil::String& privKey);
+        static Signer load(const secp256k1::PrivateKey& privKey);
+
+        void get(secp256k1::PrivateKey& out) const;
+        void get(secp256k1::PublicKey& out) const;
+        [[nodiscard]]
+        const secp256k1::PrivateKey& getPrivateKey() const;
+        [[nodiscard]]
+        const secp256k1::PublicKey& getPublicKey() const;
+
+        suil::String sign(const void* data, size_t len) const;
+
+        template <typename T>
+        suil::String sign(const T& data) const {
+            return Ego.sign(data.data(), data.size());
+        }
+
+        static bool verify(const void* data, size_t len, const suil::String& signature, const suil::String& publicKey);
+
+        template <typename T>
+        static bool verify(const T& data, const suil::String& signature, const suil::String& publicKey) {
+            return verify(data.data(), data.size(), signature, publicKey);
+        }
+
+        [[nodiscard]]
+        inline bool isValid() const { return Ego.mKey.isValid(); }
+
+        private:
+        explicit Signer(secp256k1::KeyPair&& key);
+        secp256k1::KeyPair mKey;
+    };
+
+    struct Transaction final {
+        sawtooth::protos::Transaction* operator->();
+        sawtooth::protos::Transaction& operator* ();
+        const sawtooth::protos::Transaction* operator->() const;
+        const sawtooth::protos::Transaction& operator* () const;
+    private:
+        friend struct Encoder;
+        Transaction();
+        sawtooth::protos::Transaction& get();
+
+        std::shared_ptr<sawtooth::protos::Transaction> mSelf;
+    };
+
+    struct Batch final {
+        sawtooth::protos::Batch* operator-> ();
+        sawtooth::protos::Batch& operator* ();
+        const sawtooth::protos::Batch* operator-> () const;
+        const sawtooth::protos::Batch& operator* () const;
+    private:
+        friend struct Encoder;
+        Batch();
+        sawtooth::protos::Batch& get();
+
+        std::shared_ptr<sawtooth::protos::Batch> mSelf{nullptr};
+    };
+
+    using Inputs = std::vector<String>;
+    using Outputs = std::vector<String>;
+
+    class Encoder final {
+    public:
+        Encoder(const String& family, String&& familyVersion, const String&& privateKey);
+
+        Transaction operator()(const Data& payload, const Inputs& inputs = {}, const Outputs& outputs = {}) const;
+
+        Batch operator()(const std::vector<Transaction>& txns) const;
+
+        Batch operator()(const Transaction& txn) const {
+            return Ego(std::vector<Transaction>{txn});
+        }
+
+        static void encode(sawtooth::protos::BatchList& out, const std::vector<Batch>& batches);
+        static suil::Data encode(const std::vector<Batch>& batches);
+        static void encode(Buffer& dst, const std::vector<Batch>& batches);
+        Batch encode(const suil::Data& payload, const Inputs& inputs = {}, const Outputs& outputs = {});
+        void setSigner(const String& key);
+        const String& getSigner() const { return Ego.mSignerPublicKey; }
+        const String& getBatcher() const { return Ego.mBatcherPublicKey; }
+        void setBatcher(const String& key);
+    private:
+        suil::String mFamily{};
+        suil::String mFamilyVersion{};
+        suil::String mBatcherPublicKey{};
+        suil::String mSignerPublicKey{};
+        Signer mSigner;
+        Signer mBatcher;
+    };
+
+}

--- a/libs/sawtooth/include/suil/sawtooth/dispatcher.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/dispatcher.hpp
@@ -1,0 +1,63 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/net/zmq/patterns.hpp>
+#include <suil/sawtooth/stream.hpp>
+
+namespace suil::saw {
+
+    namespace Client { struct ValidatorContext; }
+
+    define_log_tag(SAWSDK_DISPATCHER);
+
+    DECLARE_EXCEPTION(DispatcherError);
+
+    struct Dispatcher : LOGGER(SAWSDK_DISPATCHER) {
+    sptr(Dispatcher);
+
+        Dispatcher(Dispatcher&&) = delete;
+        Dispatcher(const Dispatcher&) = delete;
+        Dispatcher&operator=(Dispatcher&&) = delete;
+        Dispatcher&operator=(const Dispatcher&) = delete;
+
+        static constexpr Message::Type SERVER_CONNECT_EVENT = static_cast<Message::Type>(0xFFFE);
+        static constexpr Message::Type SERVER_DISCONNECT_EVENT = static_cast<Message::Type>(0XFFFF);
+
+        void connect(const suil::String& connString);
+        void bind();
+
+        Stream createStream();
+
+        void disconnect();
+        void exit();
+    protected:
+        friend struct TpContext;
+        friend struct Client::ValidatorContext;
+        friend class TransactionProcessor;
+        Dispatcher(net::zmq::Context& ctx);
+
+    private:
+        friend class TransactionProcessor;
+        static const suil::String DISPATCH_THREAD_ENDPOINT;
+        static const suil::String SERVER_MONITOR_ENDPOINT;
+        static const suil::String EXIT_MESSAGE;
+
+        static void receiveMessages(Dispatcher& self);
+        static void sendMessages(Dispatcher& self);
+        static void exitMonitor(Dispatcher& Self);
+
+        net::zmq::Context& mContext;
+        net::zmq::DealerSocket mServerSock;
+        net::zmq::DealerSocket mMsgSock;
+        net::zmq::DealerSocket mRequestSock;
+        net::zmq::PairSocket  mDispatchSock;
+        suil::UnorderedMap<OnAirMessage::Ptr> mOnAirMessages;
+        bool mExiting{false};
+        bool mServerConnected{false};
+    };
+
+
+}

--- a/libs/sawtooth/include/suil/sawtooth/events.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/events.hpp
@@ -1,0 +1,58 @@
+//
+// Created by Mpho Mbotho on 2021-06-30.
+//
+
+#include <suil/sawtooth/protos.hpp>
+
+#include <suil/net/zmq/patterns.hpp>
+#include <suil/net/zmq/context.hpp>
+
+#include <libmill/libmill.hpp>
+
+namespace suil::saw {
+
+    struct FilterType {
+        static constexpr  auto Unset{sawtooth::protos::EventFilter::FilterType::EventFilter_FilterType_FILTER_TYPE_UNSET};
+        static constexpr  auto SimpleAny{sawtooth::protos::EventFilter::FilterType::EventFilter_FilterType_SIMPLE_ANY};
+        static constexpr  auto SimpleAll{sawtooth::protos::EventFilter::FilterType::EventFilter_FilterType_SIMPLE_ALL};
+        static constexpr  auto RegexAny{sawtooth::protos::EventFilter::FilterType::EventFilter_FilterType_REGEX_ANY};
+        static constexpr  auto RegexAll{sawtooth::protos::EventFilter::FilterType::EventFilter_FilterType_REGEX_ALL};
+    };
+
+    using sawtooth::protos::Event;
+    struct Filter {
+        Filter(String key, String matchString, sawtooth::protos::EventFilter_FilterType filterType);
+        sawtooth::protos::EventFilter& operator()() { return mEventFilter; }
+    private:
+        sawtooth::protos::EventFilter mEventFilter{};
+    };
+
+
+    define_log_tag(SAW_EVENTS);
+    DECLARE_EXCEPTION(EventSubscriptionError);
+
+    class EventSubscription : LOGGER(SAW_EVENTS) {
+    public:
+        using Handler = std::function<void(Event)>;
+        EventSubscription(net::zmq::Context& context, String url);
+        void subscribe(const String& eventType, std::vector<Filter> filters);
+        void operator()(Handler handler);
+
+        void close();
+
+        ~EventSubscription();
+
+    private:
+        DISABLE_COPY(EventSubscription);
+        DISABLE_MOVE(EventSubscription);
+
+        void sendSubscription(suil::Data payload);
+        void sendCancelSubscription();
+        static coroutine void receiveEventsAsync(EventSubscription& S);
+        net::zmq::Context& mCtx;
+        net::zmq::DealerSocket mSock;
+        Handler mHandler{nullptr};
+        String mId;
+        mill::Event mCancelWait{};
+    };
+}

--- a/libs/sawtooth/include/suil/sawtooth/gstate.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/gstate.hpp
@@ -1,0 +1,49 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/sawtooth/stream.hpp>
+
+namespace suil::saw {
+
+    DECLARE_EXCEPTION(GlobalStateError);
+
+    class GlobalState {
+    public:
+        using KeyValue = std::tuple<suil::String, suil::Data>;
+        sptr(GlobalState);
+
+        GlobalState(GlobalState&& other);
+        GlobalState&operator=(GlobalState&& other);
+
+        GlobalState(const GlobalState&) = delete;
+        GlobalState&operator=(const GlobalState&) = delete;
+
+        Data getState(const String& address);
+
+        void getState(UnorderedMap<Data>& data, const std::vector<String>& addresses);
+
+        void setState(const suil::String& address, const suil::Data& value);
+
+        void setState(const std::vector<KeyValue>& data);
+
+        void deleteState(const suil::String& address);
+
+        void deleteState(const std::vector<String>& addresses);
+
+        void addEvent(
+                const String& eventType,
+                const std::vector<KeyValue>& values,
+                const Data& data);
+
+    private:
+        friend class TransactionProcessor;
+        GlobalState(Stream&& stream, const String& contextId);
+        Stream  mStream;
+        String  mContextId;
+    };
+
+}
+

--- a/libs/sawtooth/include/suil/sawtooth/message.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/message.hpp
@@ -1,0 +1,63 @@
+//
+// Created by Mpho Mbotho on 2021-05-07.
+//
+
+#pragma once
+
+#include <suil/base/exception.hpp>
+#include <suil/base/utils.hpp>
+#include <suil/base/string.hpp>
+#include <suil/sawtooth/protos.hpp>
+
+#include <libmill/libmill.hpp>
+
+namespace suil::saw {
+
+    struct Message {
+        using Type = ::sawtooth::protos::Message::MessageType;
+        sptr(::sawtooth::protos::Message);
+    };
+
+    DECLARE_EXCEPTION(UnexpectedMessage);
+
+    class OnAirMessage final {
+    public:
+        sptr(OnAirMessage);
+
+        OnAirMessage(suil::String id);
+
+        OnAirMessage(OnAirMessage&& other) noexcept;
+
+        OnAirMessage&operator=(OnAirMessage&& other) noexcept;
+
+        OnAirMessage(const OnAirMessage&) = delete;
+        OnAirMessage&operator=(const OnAirMessage&) = delete;
+
+        operator bool() const {
+            return Ego.mMessage != nullptr;
+        }
+
+        [[nodiscard]]
+        const suil::String& id() const { return mCorrelationId; }
+
+        template <typename T>
+        void getMessage(T& proto, Message::Type type) {
+            if (Ego.mMessage == nullptr) {
+                waitForMessage(type);
+            }
+
+            const auto& data = mMessage->content();
+            proto.ParseFromArray(data.c_str(), data.size());
+        }
+
+        void setMessage(Message::UPtr&& message);
+
+        ~OnAirMessage();
+
+    private:
+        void waitForMessage(Message::Type type);
+        Message::UPtr mMessage{nullptr};
+        suil::String mCorrelationId{};
+        mill::Event mSync{};
+    };
+}

--- a/libs/sawtooth/include/suil/sawtooth/processor.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/processor.hpp
@@ -1,0 +1,86 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/sawtooth/address.hpp>
+#include <suil/sawtooth/gstate.hpp>
+#include <suil/sawtooth/transaction.hpp>
+
+namespace suil::saw {
+
+    class ProcessorBase {
+    public:
+        sptr(ProcessorBase);
+
+        ProcessorBase(Transaction&& txn, GlobalState&& state)
+            : mTxn{std::move(txn)},
+              mState{std::move(state)}
+        {}
+
+        virtual void apply() = 0;
+
+        const Transaction& getTransaction() const { return mTxn; }
+
+        GlobalState& globalState() { return mState; }
+
+    private:
+        Transaction mTxn;
+        GlobalState mState;
+    };
+
+    template <typename AddressEncoder = DefaultAddressEncoder>
+    class Processor : public virtual ProcessorBase {
+    public:
+        Processor(AddressEncoder& ae)
+            : mAe(ae)
+        {}
+
+    protected:
+        inline String makeAddress(const suil::String& key) {
+            return mAe(key);
+        }
+
+        AddressEncoder& mAe;
+    };
+
+    class TransactionHandlerBase {
+    public:
+        sptr(TransactionHandlerBase);
+
+        const String& getFamily() const { return mFamily; }
+        std::vector<String>& getVersions() { return mVersions; }
+        std::vector<String>& getNamespaces() { return  mNamespaces; }
+        uint32& getMaxOccupancy() {return mMaxOccupancy; }
+        virtual typename ProcessorBase::Ptr getProcessor(Transaction&& txn, GlobalState&& state) = 0;
+
+    protected:
+        TransactionHandlerBase(const String& family, uint32 maxOccupancy = 0)
+            : mFamily(family.dup()),
+              mMaxOccupancy{maxOccupancy}
+        {}
+
+    private:
+        String mFamily;
+        std::vector<String> mNamespaces;
+        std::vector<String> mVersions;
+        uint32 mMaxOccupancy;
+    };
+
+    template <typename AddressEncoder = DefaultAddressEncoder>
+    class TransactionHandler : public virtual TransactionHandlerBase {
+    public:
+        TransactionHandler(const String& ns)
+            : mAe{ns}
+        {
+            getNamespaces().template emplace_back(mAe.getPrefix());
+        }
+
+        virtual AddressEncoder& addressEncoder() { return mAe; }
+    private:
+        AddressEncoder mAe;
+    };
+
+
+}

--- a/libs/sawtooth/include/suil/sawtooth/rest.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/rest.hpp
@@ -1,0 +1,49 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/sawtooth/client.hpp>
+#include <suil/sawtooth/address.hpp>
+
+#include <suil/http/client/session.hpp>
+
+namespace suil::saw::Client {
+
+    class RestApi {
+    public:
+        sptr(RestApi);
+        RestApi(const String& url,
+                 const String& family,
+                 const String& familyVersion,
+                 const String& privateKey,
+                 int port = 8008);
+
+        RestApi(RestApi&&) = delete;
+        RestApi(const RestApi&) = delete;
+        RestApi& operator=(RestApi&&) = delete;
+        RestApi& operator=(const RestApi& ) = delete;
+
+        Return<String> asyncBatches(const Data& payload, const Inputs& inputs = {}, const Outputs& outputs = {});
+        Return<String> asyncBatches(const std::vector<Batch>& batches);
+        Return<Data> getState(const String& key, bool encode = true);
+        Return<std::vector<Data>> getStates(const suil::String& prefix);
+        Return<String> getBatchStatus(const String& batchId, uint64 wait);
+
+        String getPrefix();
+        Encoder& encoder() { return  mEncoder; }
+    protected:
+        bool waitForStatus(const String& batchId, uint64 wait, std::function<bool(const String&)> checker);
+        Encoder mEncoder;
+        DefaultAddressEncoder mAddressEncoder;
+        http::cli::Session mSession;
+
+    private:
+        static const char* BATCHES_RESOURCE;
+        static const char* STATE_RESOURCE;
+        static const char* BATCH_STATUSES;
+    };
+
+
+}

--- a/libs/sawtooth/include/suil/sawtooth/stream.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/stream.hpp
@@ -1,0 +1,55 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/net/zmq/socket.hpp>
+#include <suil/net/zmq/patterns.hpp>
+
+#include <suil/sawtooth/message.hpp>
+
+namespace suil::saw {
+
+    DECLARE_EXCEPTION(StreamError);
+
+    struct Stream {
+        sptr(Stream);
+
+        Stream(Stream&& other) noexcept;
+        Stream&operator=(Stream&& other) noexcept;
+
+        Stream(const Stream&) = delete;
+        Stream&operator=(const Stream&) = delete;
+
+        template <typename T>
+        OnAirMessage::Ptr asyncSend(Message::Type type, const T& msg) {
+            suil::Data data{msg.ByteSizeLong()};
+            msg.SerializeToArray(data.data(), data.size());
+            return Ego.asyncSend(type, data);
+        }
+
+        OnAirMessage::Ptr asyncSend(Message::Type type, const suil::Data& data);
+
+        template <typename T>
+        void sendResponse(Message::Type type, const T& msg, const suil::String& correlationId) {
+            suil::Data data{msg.ByteSizeLong()};
+            msg.SerializeToArray(data.data(), data.size());
+            Ego.send(type, data, correlationId);
+        }
+
+        void send(Message::Type type, const suil::Data& data, const suil::String& correlationId);
+
+    private:
+        friend struct Dispatcher;
+        friend struct TpContext;
+        Stream(net::zmq::Context& ctx, suil::UnorderedMap<OnAirMessage::Ptr>& msgs);
+
+        suil::String getCorrelationId();
+        net::zmq::PushSocket mSocket;
+        static uint32_t CorrelationCounter;
+        suil::UnorderedMap<OnAirMessage::Ptr>& mOnAirMsgs;
+        std::atomic_uint16_t mConnected{false};
+    };
+
+}

--- a/libs/sawtooth/include/suil/sawtooth/tp.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/tp.hpp
@@ -12,6 +12,8 @@
 
 #include <suil/net/zmq/monitor.hpp>
 
+#include <csignal>
+
 namespace suil::saw {
 
     define_log_tag(SAWSDK_TP);

--- a/libs/sawtooth/include/suil/sawtooth/tp.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/tp.hpp
@@ -1,0 +1,74 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/net/zmq/context.hpp>
+#include <suil/sawtooth/dispatcher.hpp>
+#include <suil/sawtooth/transaction.hpp>
+#include <suil/sawtooth/gstate.hpp>
+#include <suil/sawtooth/processor.hpp>
+
+#include <suil/net/zmq/monitor.hpp>
+
+namespace suil::saw {
+
+    define_log_tag(SAWSDK_TP);
+
+    DECLARE_EXCEPTION(TransactionProcessorError);
+
+    using TpRequestHeaderStyle = sawtooth::protos::TpRegisterRequest_TpProcessRequestHeaderStyle;
+
+    enum FeatureVersion : std::uint32_t  {
+        FeatureUnused = 0,
+        FeatureCustomHeaderStyle = 1,
+        SdkProtocolVersion = 1
+    };
+
+    struct TransactionProcessor : LOGGER(SAWSDK_TP) {
+    public:
+            static constexpr auto HeaderStyleUnset{TpRequestHeaderStyle::TpRegisterRequest_TpProcessRequestHeaderStyle_HEADER_STYLE_UNSET};
+            static constexpr auto HeaderStyleExpanded{TpRequestHeaderStyle::TpRegisterRequest_TpProcessRequestHeaderStyle_EXPANDED};
+            static constexpr auto HeaderStyleRaw{TpRequestHeaderStyle::TpRegisterRequest_TpProcessRequestHeaderStyle_RAW};
+
+        TransactionProcessor(suil::String&& connString);
+
+        TransactionProcessor(TransactionProcessor&&) = delete;
+        TransactionProcessor(const TransactionProcessor&) = delete;
+        TransactionProcessor&operator=(TransactionProcessor&&) = delete;
+        TransactionProcessor&operator=(const TransactionProcessor&) = delete;
+
+        net::zmq::Context& zmqContext() { return mContext; }
+
+        void run();
+
+        template <typename Handler>
+        TransactionHandlerBase& registerHandler(const String& family, const String& ns)
+        {
+            idebug("registering transaction handler " PRIs, _PRIs(family));
+            Ego.mHandlers[family.dup()] = TransactionHandlerBase::UPtr{new Handler(family, ns)};
+            return *Ego.mHandlers[family];
+        }
+
+        void setHeaderStyle(TpRequestHeaderStyle headerStyle) { Ego.mHeaderStyle = headerStyle; }
+
+    private:
+        void registerAll();
+        void unRegisterAll();
+        void handleRequest(const suil::Data& msg, const suil::String& cid);
+        void initConnectionMonitor();
+        void handleExitSignal(int, siginfo_t*, void*);
+
+        net::zmq::Context mContext{};
+        net::zmq::SocketMonitor mConnMonitor;
+        String mConnString{};
+        Dispatcher mDispatcher;
+        Stream mRespStream;
+        UnorderedMap<TransactionHandlerBase::UPtr> mHandlers;
+        bool mRunning{false};
+        bool mIsSeverConnected{false};
+        TpRequestHeaderStyle mHeaderStyle{HeaderStyleUnset};
+    };
+
+}

--- a/libs/sawtooth/include/suil/sawtooth/transaction.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/transaction.hpp
@@ -1,0 +1,105 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/base/data.hpp>
+#include <suil/base/exception.hpp>
+#include <suil/sawtooth/protos.hpp>
+
+namespace suil::saw {
+
+    DECLARE_EXCEPTION(InvalidTransaction);
+    DECLARE_EXCEPTION(InternalError);
+
+    struct TransactionHeader {
+        enum Field {
+            BatcherPublicKey = 1,
+            StringDependencies,
+            FamilyName,
+            FamilyVersion,
+            Inputs,
+            Nonce,
+            Outputs,
+            PayloadSha512,
+            SignerPublicKey
+        };
+
+        TransactionHeader(sawtooth::protos::TransactionHeader* proto);
+        TransactionHeader(TransactionHeader&& other) noexcept;
+        TransactionHeader& operator=(TransactionHeader&& other) noexcept ;
+
+        TransactionHeader(const TransactionHeader&) = delete;
+        TransactionHeader& operator=(const TransactionHeader&) = delete;
+
+        virtual int getCount(Field field) const;
+        virtual suil::Data getValue(Field field, int index = 0) const;
+
+        virtual ~TransactionHeader();
+
+    private:
+        sawtooth::protos::TransactionHeader* mHeader{nullptr};
+    };
+
+    struct Transaction final {
+        Transaction(TransactionHeader&& header, std::string payload, std::string signature);
+
+        Transaction(Transaction&& other);
+
+        Transaction&operator=(Transaction&& other);
+
+        Transaction(const Transaction&) = delete;
+        Transaction&operator=(const Transaction&) = delete;
+
+        [[nodiscard]] const TransactionHeader& header() const { return mHeader; }
+
+        [[nodiscard]] suil::Data payload() const {
+            return suil::Data{mPayload.data(), mPayload.size(), false};
+        }
+
+        [[nodiscard]] suil::Data signature() const {
+            return suil::Data{mSignature.data(), mSignature.size(), false};
+        }
+
+    private:
+        TransactionHeader mHeader;
+        std::string mPayload{};
+        std::string mSignature{};
+    };
+
+    inline suil::Data fromStdString(const std::string& str) {
+        return suil::Data{str.data(), str.size(), false};
+    }
+
+    Data getNoopTransaction();
+    bool isNoopTransaction(const Transaction& txn);
+
+    template <typename T, typename V>
+    inline void setValue(T& to, void(T::*func)(const char*, size_t), const V& data) {
+        (to.*func)(reinterpret_cast<const char *>(data.data()), data.size());
+    }
+
+    template <typename T, typename V>
+    inline void setValue(T& to, void(T::*func)(const void*, size_t), const V& data) {
+        (to.*func)(data.data(), data.size());
+    }
+
+    template <typename T, typename V>
+    inline void setValue(T& to, void(T::*func)(V), const V& data) {
+        (to.*func)(data);
+    }
+
+    template <typename T>
+    inline suil::Data protoSerialize(const T& proto) {
+        suil::Data data{proto.ByteSizeLong()};
+        proto.SerializeToArray(data.data(), static_cast<int>(data.size()));
+        return data;
+    }
+
+#define protoSet(obj, prop, val) \
+        setValue(obj, &std::remove_reference_t<decltype(obj)>::set_##prop, val)
+#define protoAdd(obj, prop, val) \
+        setValue(obj, &std::remove_reference_t<decltype(obj)>::add_##prop, val)
+
+}

--- a/libs/sawtooth/include/suil/sawtooth/wallet.hpp
+++ b/libs/sawtooth/include/suil/sawtooth/wallet.hpp
@@ -1,0 +1,41 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#pragma once
+
+#include <suil/base/string.hpp>
+#include <suil/sawtooth/sawtooth.scc.hpp>
+
+namespace suil::saw::Client {
+
+    DECLARE_EXCEPTION(WalletError);
+
+    class Wallet final {
+    public:
+        Wallet(Wallet&& other) = default;
+        Wallet&operator=(Wallet&&) = default;
+
+        static Wallet open(const String& path, const String& secret);
+        static Wallet create(const String& path, const String& secret);
+        const String& get(const String& name = "") const;
+        const String& generate(const String& name);
+        const String& defaultKey() const;
+        const WalletSchema& schema() { return mData; }
+        void save();
+
+        ~Wallet();
+
+    private:
+        DISABLE_COPY(Wallet);
+        Wallet(String&& path, String&& secret);
+
+    private:
+        WalletSchema mData;
+        String mPath;
+        String mSecret;
+        bool mDirty{false};
+    };
+
+
+}

--- a/libs/sawtooth/protos/Protos.cmake
+++ b/libs/sawtooth/protos/Protos.cmake
@@ -1,0 +1,59 @@
+set(Protobuf_DEBUG ON)
+set(Protobuf_USE_STATIC_LIBS ON)
+find_package(Protobuf QUIET)
+
+if(Protobuf_VERSION)
+    message(STATUS "Using Protocol Buffers ${Protobuf_VERSION}")
+endif()
+
+set(SAWTOOTH_PROTOS
+        protos/authorization.proto
+        protos/batch.proto
+        protos/block.proto
+        protos/block_info.proto
+        protos/client_batch.proto
+        protos/client_batch_submit.proto
+        protos/client_block.proto
+        protos/client_event.proto
+        protos/client_list_control.proto
+        protos/client_peers.proto
+        protos/client_receipt.proto
+        protos/client_state.proto
+        protos/client_status.proto
+        protos/client_transaction.proto
+        protos/consensus.proto
+        protos/events.proto
+        protos/genesis.proto
+        protos/identity.proto
+        protos/merkle.proto
+        protos/network.proto
+        protos/processor.proto
+        protos/setting.proto
+        protos/state_context.proto
+        protos/transaction.proto
+        protos/transaction_receipt.proto
+        protos/validator.proto)
+protobuf_generate_cpp(SAWTOOTH_PROTO_SRCS SAWTOOTH_PROTO_HDRS ${SAWTOOTH_PROTOS})
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/sawtooth)
+set(SAWTOOTH_PROTOS_ALL ${CMAKE_CURRENT_BINARY_DIR}/protos.hpp)
+set(SAWTOOTH_PROTOS_DEV ${CMAKE_CURRENT_BINARY_DIR}/suil/sawtooth/protos.hpp)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+file(WRITE ${SAWTOOTH_PROTOS_ALL} "#ifndef __SUIL_SAWTOOTH_PROTOS_AMALGAMATE_H_\n")
+file(APPEND ${SAWTOOTH_PROTOS_ALL} "#define __SUIL_SAWTOOTH_PROTOS_AMALGAMATE_H_\n")
+
+file(WRITE ${SAWTOOTH_PROTOS_DEV} "#ifndef __SUIL_SAWTOOTH_PROTOS_AMALGAMATE_H_\n")
+file(APPEND ${SAWTOOTH_PROTOS_DEV} "#define __SUIL_SAWTOOTH_PROTOS_AMALGAMATE_H_\n")
+foreach(HEADER ${SAWTOOTH_PROTO_HDRS})
+    get_filename_component(HEADER_NAME ${HEADER} NAME)
+    file(APPEND ${SAWTOOTH_PROTOS_ALL} "#include <suil/sawtooth/protos/${HEADER_NAME}>\n")
+    file(APPEND ${SAWTOOTH_PROTOS_DEV} "#include \"../../${HEADER_NAME}\"\n")
+endforeach()
+file(APPEND ${SAWTOOTH_PROTOS_ALL} "#endif // __SUIL_SAWTOOTH_PROTOS_AMALGAMATE_H_\n")
+file(APPEND ${SAWTOOTH_PROTOS_DEV} "#endif // __SUIL_SAWTOOTH_PROTOS_AMALGAMATE_H_\n")
+
+install(FILES ${SAWTOOTH_PROTO_HDRS}
+        DESTINATION include/suil/sawtooth/protos)
+install(FILES ${SAWTOOTH_PROTOS_ALL}
+        DESTINATION include/suil/sawtooth/)

--- a/libs/sawtooth/protos/authorization.proto
+++ b/libs/sawtooth/protos/authorization.proto
@@ -1,0 +1,104 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "authorization_pb2";
+package sawtooth.protos;
+
+message ConnectionRequest {
+  // This is the first message that must be sent to start off authorization.
+  // The endpoint of the connection.
+  string endpoint = 1;
+}
+
+enum RoleType {
+  ROLE_TYPE_UNSET = 0;
+
+  // A shorthand request for asking for all allowed roles.
+  ALL = 1;
+
+  // Role defining validator to validator communication
+  NETWORK = 2;
+}
+
+message ConnectionResponse {
+  // Whether the connection can participate in authorization
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    ERROR = 2;
+  }
+
+  //Authorization Type required for the authorization procedure
+  enum AuthorizationType {
+    AUTHORIZATION_TYPE_UNSET = 0;
+    TRUST = 1;
+    CHALLENGE = 2;
+  }
+
+  message RoleEntry {
+    // The role type for this role entry
+    RoleType role = 1;
+
+    // The Authorization Type required for the above role
+    AuthorizationType auth_type = 2;
+  }
+
+  repeated RoleEntry roles = 1;
+  Status status = 2;
+}
+
+message AuthorizationTrustRequest {
+  // A set of requested RoleTypes
+  repeated RoleType roles = 1;
+  string public_key = 2;
+}
+
+message AuthorizationTrustResponse {
+  // The actual set the requester has access to
+  repeated RoleType roles = 1;
+}
+
+message AuthorizationViolation {
+  // The Role the requester did not have access to
+  RoleType violation = 1;
+}
+
+message AuthorizationChallengeRequest {
+  // Empty message sent to request a payload to sign
+}
+
+message AuthorizationChallengeResponse {
+  // Random payload that the connecting node must sign
+  bytes payload = 1;
+}
+
+message AuthorizationChallengeSubmit {
+  // public key of node
+  string public_key = 1;
+
+  // signature derived from signing the challenge payload
+  string signature = 3;
+
+  // A set of requested Roles
+  repeated RoleType roles = 4;
+}
+
+message AuthorizationChallengeResult {
+  // The approved roles for that connection
+  repeated RoleType roles = 1;
+}

--- a/libs/sawtooth/protos/batch.proto
+++ b/libs/sawtooth/protos/batch.proto
@@ -1,0 +1,52 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "batch_pb2";
+package sawtooth.protos;
+
+import "transaction.proto";
+
+message BatchHeader {
+    // Public key for the client that signed the BatchHeader
+    string signer_public_key = 1;
+
+    // List of transaction.header_signatures that match the order of
+    // transactions required for the batch
+    repeated string transaction_ids = 2;
+}
+
+message Batch {
+    // The serialized version of the BatchHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // A list of the transactions that match the list of
+    // transaction_ids listed in the batch header
+    repeated Transaction transactions = 3;
+
+    // A debugging flag which indicates this batch should be traced through the
+    // system, resulting in a higher level of debugging output.
+    bool trace = 4;
+}
+
+message BatchList {
+    repeated Batch batches = 1;
+}

--- a/libs/sawtooth/protos/block.proto
+++ b/libs/sawtooth/protos/block.proto
@@ -1,0 +1,60 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "block_pb2";
+package sawtooth.protos;
+
+import "batch.proto";
+
+message BlockHeader {
+    // Block number in the chain
+    uint64 block_num = 1;
+
+    // The header_signature of the previous block that was added to the chain.
+    string previous_block_id = 2;
+
+    // Public key for the component internal to the validator that
+    // signed the BlockHeader
+    string signer_public_key = 3;
+
+    // List of batch.header_signatures that match the order of batches
+    // required for the block
+    repeated string batch_ids = 4;
+
+    // Bytes that are set and verified by the consensus algorithm used to
+    // create and validate the block
+    bytes consensus = 5;
+
+    // The state_root_hash should match the final state_root after all
+    // transactions in the batches have been applied, otherwise the block
+    // is not valid
+    string state_root_hash = 6;
+}
+
+message Block {
+    // The serialized version of the BlockHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // A list of batches. The batches may contain new batches that other
+    // validators may not have received yet, or they will be all batches needed
+    // for block validation when passed to the journal
+    repeated Batch batches = 3;
+}

--- a/libs/sawtooth/protos/block_info.proto
+++ b/libs/sawtooth/protos/block_info.proto
@@ -1,0 +1,51 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.block_info.protobuf";
+option go_package = "block_info_pb2";
+package sawtooth.protos;
+
+message BlockInfoConfig {
+    uint64 latest_block = 1;
+    uint64 oldest_block = 2;
+    uint64 target_count = 3;
+    uint64 sync_tolerance = 4;
+}
+
+message BlockInfo {
+    // Block number in the chain
+    uint64 block_num = 1;
+    // The header_signature of the previous block that was added to the chain.
+    string previous_block_id = 2;
+    // Public key for the component internal to the validator that
+    // signed the BlockHeader
+    string signer_public_key = 3;
+    // The signature derived from signing the header
+    string header_signature = 4;
+    // Approximately when this block was committed, as a Unix UTC timestamp
+    uint64 timestamp = 5;
+}
+
+message BlockInfoTxn {
+    // The new block to add to state
+    BlockInfo block = 1;
+    // If this is set, the new target number of blocks to store in state
+    uint64 target_count = 2;
+    // If set, the new network time synchronization tolerance.
+    uint64 sync_tolerance = 3;
+}

--- a/libs/sawtooth/protos/client_batch.proto
+++ b/libs/sawtooth/protos/client_batch.proto
@@ -1,0 +1,87 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_batch_pb2";
+package sawtooth.protos;
+
+import "batch.proto";
+import "client_list_control.proto";
+
+
+// A request to return a list of batches from the validator. May include the id
+// of a particular block to be the `head` of the chain being requested. In that
+// case the list will include the batches from that block, and all batches
+// previous to that block on the chain. Filter with specific `batch_ids`.
+message ClientBatchListRequest {
+    string head_id = 1;
+    repeated string batch_ids = 2;
+    ClientPagingControls paging = 3;
+    repeated ClientSortControls sorting = 4;
+}
+
+// A response that lists batches from newest to oldest.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the head block specified was not found
+//   * NO_RESOURCE - no batches were found with the parameters specified
+//   * INVALID_PAGING - the paging controls were malformed or out of range
+//   * INVALID_SORT - the sorting controls were malformed or invalid
+message ClientBatchListResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_PAGING = 6;
+        INVALID_SORT = 7;
+        INVALID_ID = 8;
+    }
+    Status status = 1;
+    repeated Batch batches = 2;
+    string head_id = 3;
+    ClientPagingResponse paging = 4;
+}
+
+// Fetches a specific batch by its id (header_signature) from the blockchain.
+message ClientBatchGetRequest {
+    string batch_id = 1;
+}
+
+// A response that returns the batch specified by a ClientBatchGetRequest.
+//
+// Statuses:
+//   * OK - everything worked as expected, batch has been fetched
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - no batch with the specified id exists
+message ClientBatchGetResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
+        INVALID_ID = 8;
+    }
+    Status status = 1;
+    Batch batch = 2;
+}

--- a/libs/sawtooth/protos/client_batch_submit.proto
+++ b/libs/sawtooth/protos/client_batch_submit.proto
@@ -1,0 +1,105 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_batch_submit_pb2";
+package sawtooth.protos;
+
+import "batch.proto";
+
+
+// Information about the status of a batch submitted to the validator.
+//
+// Attributes:
+//     batch_id: The id (header_signature) of the batch
+//     status: The committed status of the batch
+//     invalid_transactions: Info for transactions that failed, if any
+//
+// Statuses:
+//     COMMITTED - the batch was accepted and has been committed to the chain
+//     INVALID - the batch failed validation, it should be resubmitted
+//     PENDING - the batch is still being processed
+//     UNKNOWN - no status for the batch could be found (possibly invalid)
+message ClientBatchStatus {
+    enum Status {
+        STATUS_UNSET = 0;
+        COMMITTED = 1;
+        INVALID = 2;
+        PENDING = 3;
+        UNKNOWN = 4;
+    }
+    message InvalidTransaction {
+        string transaction_id = 1;
+        string message = 2;
+        bytes extended_data = 3;
+    }
+    string batch_id = 1;
+    Status status = 2;
+    repeated InvalidTransaction invalid_transactions = 3;
+}
+
+// Submits a list of Batches to be added to the blockchain.
+message ClientBatchSubmitRequest {
+    repeated Batch batches = 1;
+}
+
+// This is a response to a submission of one or more Batches.
+// Statuses:
+//   * OK - everything with the request worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * INVALID_BATCH - the batch failed validation, likely due to a bad signature
+//   * QUEUE_FULL - the batch is unable to be queued for processing, due to
+//        a full processing queue.  The batch may be submitted again.
+message ClientBatchSubmitResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        INVALID_BATCH = 3;
+        QUEUE_FULL = 4;
+    }
+    Status status = 1;
+}
+
+// A request for the status of one or more batches, specified by id.
+// If `wait` is set to true, the validator will wait to respond until all
+// batches are committed, or until the specified `timeout` in seconds has
+// elapsed. Defaults to 300.
+message ClientBatchStatusRequest {
+    repeated string batch_ids = 1;
+    bool wait = 2;
+    uint32 timeout = 3;
+}
+
+// This is a response to a request for the status of specific batches.
+// Statuses:
+//   * OK - everything with the request worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - the response contains no data, likely because
+//     no ids were specified in the request
+message ClientBatchStatusResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
+        INVALID_ID = 8;
+    }
+    Status status = 1;
+    repeated ClientBatchStatus batch_statuses = 2;
+}

--- a/libs/sawtooth/protos/client_block.proto
+++ b/libs/sawtooth/protos/client_block.proto
@@ -1,0 +1,110 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_block_pb2";
+package sawtooth.protos;
+
+import "block.proto";
+import "client_list_control.proto";
+
+
+// A request to return a list of blocks from the validator. May include the id
+// of a particular block to be the `head` of the chain being requested. In that
+// case the list will include that block (if found), and all blocks previous
+// to it on the chain. Can be filtered using specific `block_ids`.
+message ClientBlockListRequest {
+    string head_id = 1;
+    repeated string block_ids = 2;
+    ClientPagingControls paging = 3;
+    repeated ClientSortControls sorting = 4;
+}
+
+// A response that lists a chain of blocks with the newest at the beginning,
+// and the oldest (genesis) block at the end.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the head block specified was not found
+//   * NO_RESOURCE - no blocks were found with the parameters specified
+//   * INVALID_PAGING - the paging controls were malformed or out of range
+//   * INVALID_SORT - the sorting controls were malformed or invalid
+message ClientBlockListResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_PAGING = 6;
+        INVALID_SORT = 7;
+        INVALID_ID = 8;
+    }
+    Status status = 1;
+    repeated Block blocks = 2;
+    string head_id = 3;
+    ClientPagingResponse paging = 4;
+}
+
+// A request to return a specific block from the validator. The block must be
+// specified by its unique id, in this case the block's header signature
+message ClientBlockGetByIdRequest {
+    string block_id = 1;
+}
+
+// A request to return a specific block from the validator. The block must be
+// specified by its block number
+message ClientBlockGetByNumRequest {
+    uint64 block_num = 1;
+}
+
+// A request to return a specific block from the validator. The block
+// containing the given transaction is returned. If no block on the current
+// chain contains the transaction, NO_RESOURCE is returned.
+message ClientBlockGetByTransactionIdRequest {
+    string transaction_id = 1;
+}
+
+// A request to return a specific block from the validator. The block
+// containing the given batch is returned. If no block on the current chain
+// contains the batch, NO_RESOURCE is returned.
+message ClientBlockGetByBatchIdRequest {
+    string batch_id = 1;
+}
+
+// A response that returns the block specified by a ClientBlockGetByIdRequest
+// or  ClientBlockGetByNumRequest.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - no block with the specified id exists
+message ClientBlockGetResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
+        INVALID_ID = 8;
+    }
+    Status status = 1;
+    Block block = 2;
+}

--- a/libs/sawtooth/protos/client_event.proto
+++ b/libs/sawtooth/protos/client_event.proto
@@ -1,0 +1,73 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_event_pb2";
+package sawtooth.protos;
+
+import "events.proto";
+
+
+message ClientEventsSubscribeRequest {
+    repeated EventSubscription subscriptions = 1;
+    // The block id (or ids, if trying to walk back a fork) the subscriber last
+    // received events on. It can be set to empty if it has not yet received the
+    // genesis block.
+    repeated string last_known_block_ids = 2;
+}
+
+message ClientEventsSubscribeResponse {
+    enum Status {
+         STATUS_UNSET = 0;
+         OK = 1;
+         INVALID_FILTER = 2;
+         UNKNOWN_BLOCK = 3;
+    }
+    Status status = 1;
+    // Additional information about the response status
+    string response_message = 2;
+}
+
+message ClientEventsUnsubscribeRequest {}
+
+message ClientEventsUnsubscribeResponse {
+    enum Status {
+         STATUS_UNSET = 0;
+         OK = 1;
+         INTERNAL_ERROR = 2;
+    }
+    Status status = 1;
+}
+
+message ClientEventsGetRequest {
+    repeated EventSubscription subscriptions = 1;
+    repeated string block_ids = 2;
+}
+
+message ClientEventsGetResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        INVALID_FILTER = 3;
+        UNKNOWN_BLOCK = 4;
+    }
+    Status status = 1;
+    repeated Event events = 2;
+
+}

--- a/libs/sawtooth/protos/client_list_control.proto
+++ b/libs/sawtooth/protos/client_list_control.proto
@@ -1,0 +1,52 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_list_control_pb2";
+package sawtooth.protos;
+
+// Paging controls to be sent with List requests.
+// Attributes:
+//     start: The id of a resource to start the page with
+//     limit: The number of results per page, defaults to 100 and maxes out at 1000
+message ClientPagingControls {
+    string start = 1;
+    int32 limit = 2;
+}
+
+// Information about the pagination used, sent back with List responses.
+// Attributes:
+//     next: The id of the first resource in the next page
+//     start: The id of the first resource in the returned page
+//     limit: The number of results per page, defaults to 100 and maxes out at 1000
+message ClientPagingResponse {
+    string next = 1;
+    string start = 2;
+    int32 limit = 3;
+
+}
+
+// Sorting controls to be sent with List requests. More than one can be sent.
+// If so, the first is used, and additional controls are tie-breakers.
+// Attributes:
+//     keys: Nested set of keys to sort by (i.e. ['default, block_num'])
+//     reverse: Whether or not to reverse the sort (i.e. descending order)
+message ClientSortControls {
+    repeated string keys = 1;
+    bool reverse = 2;
+}

--- a/libs/sawtooth/protos/client_peers.proto
+++ b/libs/sawtooth/protos/client_peers.proto
@@ -1,0 +1,34 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_peer";
+package sawtooth.protos;
+
+message ClientPeersGetRequest{
+}
+
+message ClientPeersGetResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
+    }
+    Status status = 1;
+    repeated string peers = 2;
+}

--- a/libs/sawtooth/protos/client_receipt.proto
+++ b/libs/sawtooth/protos/client_receipt.proto
@@ -1,0 +1,47 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_receipt_pb2";
+package sawtooth.protos;
+
+import "transaction_receipt.proto";
+
+// Fetches a specific txn by its id (header_signature) from the blockchain.
+message ClientReceiptGetRequest {
+    repeated string transaction_ids = 1;
+}
+
+// A response that returns the txn receipt specified by a
+// ClientTransactionReceiptGetRequest.
+//
+// Statuses:
+//   * OK - everything worked as expected, txn receipt has been fetched
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - no receipt exists for the transaction id specified
+message ClientReceiptGetResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
+        INVALID_ID = 8;
+    }
+    Status status = 1;
+    repeated TransactionReceipt receipts = 2;
+}

--- a/libs/sawtooth/protos/client_state.proto
+++ b/libs/sawtooth/protos/client_state.proto
@@ -1,0 +1,109 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_state_pb2";
+package sawtooth.protos;
+
+import "client_list_control.proto";
+
+
+// A request to list every entry in global state. Defaults to the most current
+// tree, but can fetch older state by specifying a state root. Results can be
+// further filtered by specifying a subtree with a partial address.
+message ClientStateListRequest {
+    string state_root = 1;
+    string address = 3;
+    ClientPagingControls paging = 4;
+    repeated ClientSortControls sorting = 5;
+}
+
+// A response that lists the data Entries from global state, filtered by state
+// root or subtree address according to the request. Returns the state root
+// used to facilitate future requests.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the head block or merkle_root specified was not found
+//   * NO_RESOURCE - the head/root specified is valid, but contains no data
+//   * INVALID_PAGING - the paging controls were malformed or out of range
+//   * INVALID_SORT - the sorting controls were malformed or invalid
+
+message ClientStateListResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_PAGING = 6;
+        INVALID_SORT = 7;
+        INVALID_ADDRESS = 8;
+        INVALID_ROOT = 9;
+    }
+
+    // An entry in the State
+    message Entry {
+        string address = 1;
+        bytes data = 2;
+    }
+
+    Status status = 1;
+    repeated Entry entries = 2;
+    string state_root = 3;
+    ClientPagingResponse paging = 4;
+}
+
+// A request from a client for a particular entry in global state.
+// Like State List, it defaults to the newest state, but a state root
+// can be used to specify older data. Unlike State List the request must be
+// provided with a full address that corresponds to a single entry.
+message ClientStateGetRequest {
+    string state_root = 1;
+    string address = 3;
+}
+
+// The response to a State Get Request from the client. Sends back just
+// the data stored at the entry, not the address. Also sends back the
+// head block id used to facilitate further requests.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the state_root specified was not found
+//   * NO_RESOURCE - the address specified doesn't exist
+//   * INVALID_ADDRESS - address isn't a valid, i.e. it's a subtree (truncated)
+message ClientStateGetResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_ADDRESS = 6;
+        INVALID_ROOT = 7;
+    }
+    Status status = 1;
+    bytes value = 2;
+    string state_root = 3;
+}

--- a/libs/sawtooth/protos/client_status.proto
+++ b/libs/sawtooth/protos/client_status.proto
@@ -1,0 +1,44 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_status";
+
+// A request to get miscellaneous information about the validator
+message ClientStatusGetRequest{
+}
+
+message ClientStatusGetResponse {
+  // The status of the response message, not the validator's status
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    ERROR = 2;
+  }
+
+  // Information about the validator's peers
+  message Peer {
+    // The peer's public network endpoint
+    string endpoint = 1;
+  }
+
+  Status status = 1;
+  repeated Peer peers = 2;
+  // The validator's public network endpoint
+  string endpoint = 3;
+}

--- a/libs/sawtooth/protos/client_transaction.proto
+++ b/libs/sawtooth/protos/client_transaction.proto
@@ -1,0 +1,87 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_transaction_pb2";
+package sawtooth.protos;
+
+import "transaction.proto";
+import "client_list_control.proto";
+
+
+// A request to return a list of txns from the validator. May include the id
+// of a particular block to be the `head` of the chain being requested. In that
+// case the list will include the txns from that block, and all txns
+// previous to that block on the chain. Filter with specific `transaction_ids`.
+message ClientTransactionListRequest {
+    string head_id = 1;
+    repeated string transaction_ids = 2;
+    ClientPagingControls paging = 3;
+    repeated ClientSortControls sorting = 4;
+}
+
+// A response that lists transactions from newest to oldest.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the head block specified was not found
+//   * NO_RESOURCE - no txns were found with the parameters specified
+//   * INVALID_PAGING - the paging controls were malformed or out of range
+//   * INVALID_SORT - the sorting controls were malformed or invalid
+message ClientTransactionListResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_PAGING = 6;
+        INVALID_SORT = 7;
+        INVALID_ID = 8;
+    }
+    Status status = 1;
+    repeated Transaction transactions = 2;
+    string head_id = 3;
+    ClientPagingResponse paging = 4;
+}
+
+// Fetches a specific txn by its id (header_signature) from the blockchain.
+message ClientTransactionGetRequest {
+    string transaction_id = 1;
+}
+
+// A response that returns the txn specified by a ClientTransactionGetRequest.
+//
+// Statuses:
+//   * OK - everything worked as expected, txn has been fetched
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - no txn with the specified id exists
+message ClientTransactionGetResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
+        INVALID_ID = 8;
+    }
+    Status status = 1;
+    Transaction transaction = 2;
+}

--- a/libs/sawtooth/protos/consensus.proto
+++ b/libs/sawtooth/protos/consensus.proto
@@ -1,0 +1,546 @@
+// Copyright 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+// --== Data Structures ==--
+
+message ConsensusPeerMessageHeader {
+  // Public key for the component internal to the validator that
+  // signed the message
+  bytes signer_id = 1;
+
+  // The sha512 hash of the encoded message
+  bytes content_sha512 = 2;
+  // Interpretation is left to the consensus engine implementation
+  string message_type = 5;
+
+  // Used to identify the consensus engine that produced this message
+  string name = 3;
+  string version = 4;
+}
+
+// A consensus-related message sent between peers
+message ConsensusPeerMessage {
+  // The serialized version of the ConsensusPeerMessageHeader
+  bytes header = 1;
+
+  // The signature derived from signing the header
+  bytes header_signature = 3;
+
+  // The opaque payload to send to other nodes
+  bytes content = 2;
+}
+
+// All information about a block that is relevant to consensus
+message ConsensusBlock {
+  bytes block_id = 1;
+  bytes previous_id = 2;
+  // The id of peer that signed this block
+  bytes signer_id = 3;
+  uint64 block_num = 4;
+  bytes payload = 5;
+  // A summary of the contents of the block
+  bytes summary = 6;
+}
+
+// Information about a peer that is relevant to consensus
+message ConsensusPeerInfo {
+  // The unique id for this peer. This can be correlated with the signer id
+  // on consensus blocks.
+  bytes peer_id = 1;
+}
+
+// A settings key-value pair
+message ConsensusSettingsEntry {
+  string key = 1;
+  string value = 2;
+}
+
+// A state key-value pair
+message ConsensusStateEntry {
+  string address = 1;
+  bytes data = 2;
+}
+
+// --== Registration ==--
+
+// Sent to connect with the validator
+message ConsensusRegisterRequest {
+  message Protocol {
+    string name = 1;
+    string version = 2;
+  }
+
+  // The name of this consensus engine
+  string name = 1;
+  // The version of this consensus engine
+  string version = 2;
+  // Any additional name/version pairs the consensus engine supports
+  repeated Protocol additional_protocols = 3;
+}
+
+message ConsensusRegisterResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+  }
+
+  Status status = 1;
+
+  // Startup Info
+  ConsensusBlock chain_head = 2;
+  repeated ConsensusPeerInfo peers = 3;
+  ConsensusPeerInfo local_peer_info = 4;
+}
+
+// --== Notifications ==--
+
+// The following are notifications provided by the validator to the consensus
+// engine. An ack should be sent in response to all notifications.
+
+// - P2P -
+
+// A new peer was added
+message ConsensusNotifyPeerConnected {
+  ConsensusPeerInfo peer_info = 1;
+}
+
+// An existing peer was dropped
+message ConsensusNotifyPeerDisconnected {
+  bytes peer_id = 1;
+}
+
+// A new message was received from a peer
+message ConsensusNotifyPeerMessage {
+  // The message sent
+  ConsensusPeerMessage message = 1;
+  // The node that sent the message, not necessarily the node that created it
+  bytes sender_id = 2;
+}
+
+// - Blocks -
+
+// A new block was received and passed initial consensus validation
+message ConsensusNotifyBlockNew {
+  ConsensusBlock block = 1;
+}
+
+// This block can be committed successfully
+message ConsensusNotifyBlockValid {
+  bytes block_id = 1;
+}
+
+// This block cannot be committed successfully
+message ConsensusNotifyBlockInvalid {
+  bytes block_id = 1;
+}
+
+// This block has been committed
+message ConsensusNotifyBlockCommit {
+  bytes block_id = 1;
+}
+
+// The engine has been activated
+message ConsensusNotifyEngineActivated {
+  // Startup Info
+  ConsensusBlock chain_head = 1;
+  repeated ConsensusPeerInfo peers = 2;
+  ConsensusPeerInfo local_peer_info = 3;
+}
+
+// The engine has been deactivated
+message ConsensusNotifyEngineDeactivated {}
+
+// Confirm that the notification was received. The validator message
+// correlation id is used to determine which notification this is an ack for.
+message ConsensusNotifyAck {}
+
+// --== Services Provided ==--
+
+// The following are services provided by the validator to the consensus
+// engine. All service messages have at a minimum the following possible return
+// statuses:
+//
+//    STATUS_UNSET
+//        No status was set by the validator, this should never happen
+//    OK
+//        The request was completed successfully
+//    BAD_REQUEST
+//        The request was malformed in some way
+//    SERVICE_ERROR
+//        The validator failed to perform the request
+//    NOT_READY
+//        The validator is not accepting requests, usually because it is still
+//        starting up
+//    NOT_ACTIVE_ENGINE
+//        The consensus engine making the request is not the active engine
+//
+// Additionally, messages may have the following additional return statuses:
+//
+//    INVALID_STATE
+//        The request is not valid given the current state of the validator
+//    UNKNOWN_BLOCK
+//        No block with the given id could be found
+//    UNKNOWN_PEER
+//        No peer with the given id could be found
+
+// - P2P Messaging -
+
+// Send a consensus message to a specific, connected peer
+message ConsensusSendToRequest {
+  // Payload to send to peer
+  //
+  // NOTE: This payload will be wrapped up in a ConsensusPeerMessage struct,
+  // which includes computing its SHA-512 digest, inserting this engine's
+  // registration info, and the validator's public key, and signing everything
+  // with the validator's private key.
+  bytes content = 1;
+  string message_type = 3;
+
+  // Peer that this message is destined for
+  bytes receiver_id = 2;
+}
+
+message ConsensusSendToResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_PEER = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+  Status status = 1;
+}
+
+// Broadcast a consensus message to all peers
+message ConsensusBroadcastRequest {
+  // Payload to broadcast peers
+  //
+  // NOTE: This payload will be wrapped up in a ConsensusPeerMessage struct,
+  // which includes computing its SHA-512 digest, inserting this engine's
+  // registration info, and the validator's public key, and signing everything
+  // with the validator's private key.
+  bytes content = 1;
+  string message_type = 2;
+}
+
+message ConsensusBroadcastResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+    NOT_ACTIVE_ENGINE = 5;
+  }
+  Status status = 1;
+}
+
+// - Block Creation -
+
+// Initialize a new block built on the block with the given previous id and
+// begin adding batches to it. If no previous id is specified, the current
+// head will be used.
+message ConsensusInitializeBlockRequest {
+  bytes previous_id = 1;
+}
+
+message ConsensusInitializeBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    INVALID_STATE = 5;
+    UNKNOWN_BLOCK = 6;
+
+    NOT_ACTIVE_ENGINE = 7;
+  }
+  Status status = 1;
+}
+
+// Stop adding batches to the current block and return a summary of its
+// contents.
+message ConsensusSummarizeBlockRequest {}
+
+message ConsensusSummarizeBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    INVALID_STATE = 5;
+    BLOCK_NOT_READY = 6;
+
+    NOT_ACTIVE_ENGINE = 7;
+  }
+  Status status = 1;
+
+  // A summary of the block contents
+  bytes summary = 2;
+}
+
+// Insert the given consensus data into the block and sign it. If this call is
+// successful, the consensus engine will receive the block afterwards.
+message ConsensusFinalizeBlockRequest {
+  // The consensus data to include in the finalized block
+  bytes data = 1;
+}
+
+message ConsensusFinalizeBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    INVALID_STATE = 5;
+    BLOCK_NOT_READY = 6;
+
+    NOT_ACTIVE_ENGINE = 7;
+  }
+  Status status = 1;
+
+  // The block id of the newly created block
+  bytes block_id = 2;
+}
+
+// Stop adding batches to the current block and abandon it.
+message ConsensusCancelBlockRequest {}
+
+message ConsensusCancelBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    INVALID_STATE = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// - Block Directives -
+
+// Request that, for each block block in order, the block is checked to
+// determine whether the block can be committed successfully or not. Blocks
+// may be checked in parallel. If a new request arrives, it overrides the
+// previous request allowing the engine to reprioritize the list of blocks to
+// check.
+//
+// NOTE: OK does not mean the blocks will all commit successfully, only that
+// the directive was received successfully. The engine must listen for
+// notifications from the consuming component to learn if the blocks would
+// commit or not.
+message ConsensusCheckBlocksRequest {
+  repeated bytes block_ids = 1;
+}
+
+message ConsensusCheckBlocksResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// Request that the block be committed. This request fails if the block has
+// not already been checked.
+//
+// NOTE: OK does not mean the block has been committed, only that the directive
+// was received successfully. The engine must listen for notifications from the
+// consuming component to learn when the block commits.
+message ConsensusCommitBlockRequest {
+  bytes block_id = 1;
+}
+
+message ConsensusCommitBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// Inform the consuming component that this block is no longer being considered
+// and can be held or freed as needed.
+message ConsensusIgnoreBlockRequest {
+  bytes block_id = 1;
+}
+
+message ConsensusIgnoreBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// Fail this block and any of its descendants and purge them as needed.
+message ConsensusFailBlockRequest {
+  bytes block_id = 1;
+}
+
+message ConsensusFailBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// - Queries -
+
+// Retrieve consensus-related information about blocks. If some blocks could
+// not be found, only the blocks that could be found will be returned.
+message ConsensusBlocksGetRequest {
+  repeated bytes block_ids = 1;
+}
+
+message ConsensusBlocksGetResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+  repeated ConsensusBlock blocks = 2;
+}
+
+// Retrieve consensus-related information about the chain head.
+message ConsensusChainHeadGetRequest {}
+
+message ConsensusChainHeadGetResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    NO_CHAIN_HEAD = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+  ConsensusBlock block = 2;
+}
+
+// Read the values of these settings from state as of the given block. If some
+// values settings keys cannot be found, the keys that were found will be
+// returned.
+message ConsensusSettingsGetRequest {
+  bytes block_id = 1;
+  repeated string keys = 2;
+}
+
+message ConsensusSettingsGetResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+  repeated ConsensusSettingsEntry entries = 2;
+}
+
+// Read the data at these addresses from state as of the given block. If some
+// addresses cannot be found, state at the addresses that were found will be
+// returned.
+message ConsensusStateGetRequest {
+  bytes block_id = 1;
+  repeated string addresses = 2;
+}
+
+message ConsensusStateGetResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+  repeated ConsensusStateEntry entries = 2;
+}

--- a/libs/sawtooth/protos/events.proto
+++ b/libs/sawtooth/protos/events.proto
@@ -1,0 +1,66 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "events_pb2";
+package sawtooth.protos;
+
+message Event {
+  // Used to subscribe to events and servers as a hint for how to deserialize
+  // event_data and what pairs to expect in attributes.
+  string event_type = 1;
+
+  // Transparent data defined by the event_type.
+  message Attribute {
+    string key = 1;
+    string value = 2;
+  }
+  repeated Attribute attributes = 2;
+
+  // Opaque data defined by the event_type.
+  bytes  data = 3;
+}
+
+message EventList {
+    repeated Event events = 1;
+}
+
+message EventFilter {
+    // EventFilter is used when subscribing to events to limit the events
+    // received within a given event type. See
+    // validator/server/events/subscription.py for further explanation.
+    string key = 1;
+    string match_string = 2;
+
+    enum FilterType {
+      FILTER_TYPE_UNSET = 0;
+      SIMPLE_ANY = 1;
+      SIMPLE_ALL = 2;
+      REGEX_ANY  = 3;
+      REGEX_ALL  = 4;
+    }
+    FilterType filter_type = 3;
+}
+
+message EventSubscription {
+    // EventSubscription is used when subscribing to events to specify the type
+    // of events being subscribed to, along with any additional filters. See
+    // validator/server/events/subscription.py for further explanation.
+    string event_type = 1;
+    repeated EventFilter filters = 2;
+}

--- a/libs/sawtooth/protos/genesis.proto
+++ b/libs/sawtooth/protos/genesis.proto
@@ -1,0 +1,28 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "genesis_pb2";
+package sawtooth.protos;
+
+import "batch.proto";
+
+message GenesisData {
+    // The list of batches that will be applied during the genesis process
+    repeated Batch batches = 1;
+}

--- a/libs/sawtooth/protos/identity.proto
+++ b/libs/sawtooth/protos/identity.proto
@@ -1,0 +1,63 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.identity.protobuf";
+package sawtooth.protos;
+
+message Policy {
+
+  enum EntryType {
+    ENTRY_TYPE_UNSET = 0;
+    PERMIT_KEY = 1;
+    DENY_KEY = 2;
+  }
+
+  message Entry {
+    // Whether this is a Permit_KEY or Deny_KEY entry
+    EntryType type = 1;
+
+    // This should be a public key or * to refer to all participants.
+    string  key = 2;
+  }
+
+  // name of the policy, this should be unique.
+  string name = 1;
+
+  // list of Entries
+  // The entries will be processed in order from first to last.
+  repeated Entry entries = 2;
+}
+
+// Policy will be stored in a Policy list to account for state collisions
+message PolicyList {
+  repeated Policy policies = 1;
+}
+
+
+message Role {
+  // Role name
+  string name = 1;
+
+  // Name of corresponding policy
+  string policy_name = 2;
+}
+
+// Roles will be stored in a RoleList to account for state collisions
+message RoleList {
+  repeated Role roles = 1;
+}

--- a/libs/sawtooth/protos/merkle.proto
+++ b/libs/sawtooth/protos/merkle.proto
@@ -1,0 +1,43 @@
+// Copyright 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "merkle_pb2";
+package sawtooth.protos;
+
+// An Entry in the change log for a given state root.
+message ChangeLogEntry {
+    // A state root that succeed this root.
+    message Successor {
+        // A root hash of a merkle trie based of off this root.
+        bytes successor = 1;
+
+        // The keys (i.e. hashes) that were replaced (i.e. deleted) by this
+        // successor.  These may be deleted during pruning.
+        repeated bytes deletions = 2;
+    }
+
+    // A root hash of a merkle trie this tree was based off.
+    bytes parent = 1;
+
+    // The hashes that were added for this root. These may be deleted during
+    // pruning, if this root is being abandoned.
+    repeated bytes additions = 2;
+
+    // The list of successors.
+    repeated Successor successors = 3;
+}

--- a/libs/sawtooth/protos/network.proto
+++ b/libs/sawtooth/protos/network.proto
@@ -1,0 +1,116 @@
+// Copyright 2016, 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "network_pb2";
+package sawtooth.protos;
+
+// The disconnect message from a client to the server
+message DisconnectMessage {
+}
+
+// The registration request from a peer to the validator
+message PeerRegisterRequest {
+    string endpoint = 1;
+    // The current version of the network protocol that is being used by the
+    // sender.  This version is an increasing value.
+    uint32 protocol_version = 2;
+}
+
+// The unregistration request from a peer to the validator
+message PeerUnregisterRequest {
+}
+
+message GetPeersRequest {
+}
+
+message GetPeersResponse {
+    repeated string peer_endpoints = 1;
+}
+
+message PingRequest {
+}
+
+message PingResponse{
+}
+
+message GossipMessage {
+    enum ContentType{
+        CONTENT_TYPE_UNSET = 0;
+        BLOCK = 1;
+        BATCH = 2;
+        CONSENSUS = 3;
+    }
+    bytes content = 1;
+    ContentType content_type = 2;
+    uint32 time_to_live = 3;
+}
+
+// A response sent from the validator to the peer acknowledging message
+// receipt
+message NetworkAcknowledgement {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
+    }
+
+    Status status = 1;
+}
+
+message GossipBlockRequest {
+    // The id of the block that is being requested
+    string block_id = 1;
+
+    // A random string that provides uniqueness for requests with
+    // otherwise identical fields.
+    string nonce = 2;
+    uint32 time_to_live = 3;
+
+}
+
+message GossipBlockResponse {
+    // The block
+    bytes content = 1;
+}
+
+message GossipBatchResponse {
+    //The batch
+    bytes content = 1;
+}
+
+message GossipBatchByBatchIdRequest {
+    // The id of the batch that is being requested
+    string id = 1;
+
+    // A random string that provides uniqueness for requests with
+    // otherwise identical fields.
+    string nonce = 2;
+    uint32 time_to_live = 3;
+
+}
+
+message GossipBatchByTransactionIdRequest {
+    // The id's of the transaction that are in the batches requested
+    repeated string ids = 1;
+
+    // A random string that provides uniqueness for requests with
+    // otherwise identical fields.
+    string nonce = 2;
+    uint32 time_to_live = 3;
+
+}

--- a/libs/sawtooth/protos/processor.proto
+++ b/libs/sawtooth/protos/processor.proto
@@ -1,0 +1,150 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "processor_pb2";
+package sawtooth.protos;
+
+import "transaction.proto";
+
+
+// The registration request from the transaction processor to the
+// validator/executor.
+//
+// The protocol_version field is used to check if the validator supports
+// requested features by a transaction processor.
+// Following are the versions supported:
+//     1    Transaction processor can request for either raw header bytes or
+//          deserialized TransactionHeader field in the TpProcessRequest
+//          message. The default option is set to send deserialized
+//          TransactionHeader.
+message TpRegisterRequest {
+    // enum used to fill in transaction header field in TpProcessRequest.
+    // This field can be set before transaction processor registers with
+    // validator.
+    enum TpProcessRequestHeaderStyle {
+        HEADER_STYLE_UNSET = 0;
+        EXPANDED = 1;
+        RAW = 2;
+    }
+
+    // A settled upon name for the capabilities of the transaction processor.
+    // For example: intkey, xo
+    string family = 1;
+
+    // The version supported.  For example:
+    //      1.0  for version 1.0
+    //      2.1  for version 2.1
+    string version = 2;
+
+    // The namespaces this transaction processor expects to interact with
+    // when processing transactions matching this specification; will be
+    // enforced by the state API on the validator.
+    repeated string namespaces = 4;
+
+    // The maximum number of transactions that this transaction processor can
+    // handle at once.
+    uint32 max_occupancy = 5;
+
+    // Validator can make use of this field to check if the requested features
+    // are supported. Registration requests can be either accepted or rejected
+    // based on this field.
+    uint32 protocol_version = 6;
+
+    // Setting it to RAW, validator would fill in serialized transaction header
+    // when sending TpProcessRequest to the transaction processor.
+    TpProcessRequestHeaderStyle request_header_style = 7;
+}
+
+// A response sent from the validator to the transaction processor
+// acknowledging the registration
+message TpRegisterResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
+    }
+
+    Status status = 1;
+
+    // Respond back with protocol_version, the value that can be used by SDK to
+    // know if validator supports expected feature.
+    uint32 protocol_version = 2;
+}
+
+// The unregistration request from the transaction processor to the
+// validator/executor. The correct handlers are determined from the
+// zeromq identity of the tp, on the validator side.
+message TpUnregisterRequest {
+
+}
+
+// A response sent from the validator to the transaction processor
+// acknowledging the unregistration
+message TpUnregisterResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
+    }
+
+    Status status = 1;
+}
+
+
+// The request from the validator/executor of the transaction processor
+// to verify a transaction.
+message TpProcessRequest {
+    // The de-serialized transaction header from client request
+    TransactionHeader header = 1;
+
+    // The transaction payload
+    bytes payload = 2;
+
+    // The transaction header_signature
+    string signature = 3;
+
+    // The context_id for state requests.
+    string context_id = 4;
+
+    // The serialized header as received by client.
+    // Controlled by a flag during transaction processor registration.
+    bytes header_bytes = 5;
+}
+
+
+// The response from the transaction processor to the validator/executor
+// used to respond about the validity of a transaction
+message TpProcessResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INVALID_TRANSACTION = 2;
+        INTERNAL_ERROR = 3;
+    }
+
+    Status status = 1;
+
+    // A message to include on responses in the cases where
+    // status is either INVALID_TRANSACTION or INTERNAL_ERROR
+    string message = 2;
+
+    // Information that may be included with the response.
+    // This information is an opaque, application-specific encoded block of
+    // data that will be propagated back to the transaction submitter.
+    bytes extended_data = 3;
+}

--- a/libs/sawtooth/protos/setting.proto
+++ b/libs/sawtooth/protos/setting.proto
@@ -1,0 +1,32 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "setting_pb2";
+package sawtooth.protos;
+
+// Setting Container for on-chain configuration key/value pairs
+message Setting {
+    // Contains a setting entry (or entries, in the case of collisions).
+    message Entry {
+        string key = 1;
+        string value = 2;
+    }
+
+    // List of setting entries - more than one implies a state key collision
+    repeated Entry entries = 1;
+}

--- a/libs/sawtooth/protos/state_context.proto
+++ b/libs/sawtooth/protos/state_context.proto
@@ -1,0 +1,117 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "state_context_pb2";
+package sawtooth.protos;
+
+import "events.proto";
+
+// An entry in the State
+message TpStateEntry {
+    string address = 1;
+    bytes data = 2;
+}
+
+// A request from a handler/tp for the values at a series of addresses
+message TpStateGetRequest {
+    // The context id that references a context in the contextmanager
+    string context_id = 1;
+    repeated string addresses = 2;
+}
+
+// A response from the contextmanager/validator with a series of State entries
+message TpStateGetResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        AUTHORIZATION_ERROR = 2;
+    }
+
+    repeated TpStateEntry entries = 1;
+    Status status = 2;
+}
+
+// A request from the handler/tp to put entries in the state of a context
+message TpStateSetRequest {
+    string context_id = 1;
+    repeated TpStateEntry entries = 2;
+}
+
+// A response from the contextmanager/validator with the addresses that were set
+message TpStateSetResponse {
+  enum Status {
+      STATUS_UNSET = 0;
+      OK = 1;
+      AUTHORIZATION_ERROR = 2;
+  }
+
+    repeated string addresses = 1;
+    Status status = 2;
+}
+
+// A request from the handler/tp to delete state entries at an collection of addresses
+message TpStateDeleteRequest {
+    string context_id = 1;
+    repeated string addresses = 2;
+}
+
+// A response form the contextmanager/validator with the addresses that were deleted
+message TpStateDeleteResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        AUTHORIZATION_ERROR = 2;
+    }
+
+    repeated string addresses = 1;
+    Status status = 2;
+}
+
+// The request from the transaction processor to the validator append data
+// to a transaction receipt
+message TpReceiptAddDataRequest {
+    // The context id that references a context in the context manager
+    string context_id = 1;
+    bytes data = 3;
+}
+
+// The response from the validator to the transaction processor to verify that
+// data has been appended to a transaction receipt
+message TpReceiptAddDataResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
+    }
+
+    Status status = 2;
+}
+
+message TpEventAddRequest {
+    string context_id = 1;
+    Event event = 2;
+}
+
+message TpEventAddResponse {
+    enum Status {
+      STATUS_UNSET = 0;
+      OK = 1;
+      ERROR = 2;
+    }
+    Status status = 2;
+}

--- a/libs/sawtooth/protos/transaction.proto
+++ b/libs/sawtooth/protos/transaction.proto
@@ -1,0 +1,74 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "transaction_pb2";
+package sawtooth.protos;
+
+message TransactionHeader {
+    // Public key for the client who added this transaction to a batch
+    string batcher_public_key = 1;
+
+    // A list of transaction signatures that describe the transactions that
+    // must be processed before this transaction can be valid
+    repeated string dependencies = 2;
+
+    // The family name correlates to the transaction processor's family name
+    // that this transaction can be processed on, for example 'intkey'
+    string family_name = 3;
+
+    // The family version correlates to the transaction processor's family
+    // version that this transaction can be processed on, for example "1.0"
+    string family_version = 4;
+
+    // A list of addresses that are given to the context manager and control
+    // what addresses the transaction processor is allowed to read from.
+    repeated string inputs = 5;
+
+    // A random string that provides uniqueness for transactions with
+    // otherwise identical fields.
+    string nonce = 6;
+
+    // A list of addresses that are given to the context manager and control
+    // what addresses the transaction processor is allowed to write to.
+    repeated string outputs = 7;
+
+    //The sha512 hash of the encoded payload
+    string payload_sha512 = 9;
+
+    // Public key for the client that signed the TransactionHeader
+    string signer_public_key = 10;
+}
+
+message Transaction {
+    // The serialized version of the TransactionHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // The payload is the encoded family specific information of the
+    // transaction. Example cbor({'Verb': verb, 'Name': name,'Value': value})
+    bytes payload = 3;
+}
+
+// A simple list of transactions that needs to be serialized before
+// it can be transmitted to a batcher.
+message TransactionList {
+    repeated Transaction transactions = 1;
+}

--- a/libs/sawtooth/protos/transaction_receipt.proto
+++ b/libs/sawtooth/protos/transaction_receipt.proto
@@ -1,0 +1,54 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "txn_receipt_pb2";
+package sawtooth.protos;
+
+import "events.proto";
+
+
+message TransactionReceipt {
+  // State changes made by this transaction
+  // StateChange is defined in protos/transaction_receipt.proto
+  repeated StateChange state_changes = 1;
+  // Events fired by this transaction
+  repeated Event events = 2;
+  // Transaction family defined data
+  repeated bytes data = 3;
+
+  string transaction_id = 4;
+}
+
+//  StateChange objects have the type of SET, which is either an insert or
+//  update, or DELETE. Items marked as a DELETE will have no byte value.
+message StateChange {
+    enum Type {
+        TYPE_UNSET = 0;
+        SET = 1;
+        DELETE = 2;
+    }
+    string address = 1;
+    bytes value = 2;
+    Type type = 3;
+}
+
+// A collection of state changes.
+message StateChangeList {
+    repeated StateChange state_changes = 1;
+}

--- a/libs/sawtooth/protos/validator.proto
+++ b/libs/sawtooth/protos/validator.proto
@@ -1,0 +1,227 @@
+// Copyright 2016, 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "validator_pb2";
+package sawtooth.protos;
+
+// A list of messages to be transmitted together.
+message MessageList {
+    repeated Message messages = 1;
+}
+
+// The message passed between the validator and client, containing the
+// header fields and content.
+message Message {
+
+    enum MessageType {
+        DEFAULT = 0;
+        // Registration request from the transaction processor to the validator
+        TP_REGISTER_REQUEST = 1;
+        // Registration response from the validator to the
+        // transaction processor
+        TP_REGISTER_RESPONSE = 2;
+        // Tell the validator that the transaction processor
+        // won't take any more transactions
+        TP_UNREGISTER_REQUEST = 3;
+        // Response from the validator to the tp that it won't
+        // send any more transactions
+        TP_UNREGISTER_RESPONSE = 4;
+        // Process Request from the validator/executor to the
+        // transaction processor
+        TP_PROCESS_REQUEST = 5;
+        // Process response from the transaction processor to the validator/executor
+        TP_PROCESS_RESPONSE = 6;
+        // State get request from the transaction processor to validator/context_manager
+        TP_STATE_GET_REQUEST = 7;
+        // State get response from the validator/context_manager to the transaction processor
+        TP_STATE_GET_RESPONSE = 8;
+        // State set request from the transaction processor to the validator/context_manager
+        TP_STATE_SET_REQUEST = 9;
+        // State set response from the validator/context_manager to the transaction processor
+        TP_STATE_SET_RESPONSE = 10;
+        // State delete request from the transaction processor to the validator/context_manager
+        TP_STATE_DELETE_REQUEST = 11;
+        // State delete response from the validator/context_manager to the transaction processor
+        TP_STATE_DELETE_RESPONSE = 12;
+        // Message to append data to a transaction receipt
+        TP_RECEIPT_ADD_DATA_REQUEST = 13;
+        // Response from validator to tell transaction processor that data has been appended
+        TP_RECEIPT_ADD_DATA_RESPONSE = 14;
+        // Message to add event
+        TP_EVENT_ADD_REQUEST = 15;
+        // Response from validator to tell transaction processor that event has been created
+        TP_EVENT_ADD_RESPONSE = 16;
+
+        // Submission of a batchlist from the web api or another client to the validator
+        CLIENT_BATCH_SUBMIT_REQUEST = 100;
+        // Response from the validator to the web api/client that the submission was accepted
+        CLIENT_BATCH_SUBMIT_RESPONSE = 101;
+        // A request to list blocks from the web api/client to the validator
+        CLIENT_BLOCK_LIST_REQUEST = 102;
+        CLIENT_BLOCK_LIST_RESPONSE = 103;
+        CLIENT_BLOCK_GET_BY_ID_REQUEST = 104;
+        CLIENT_BLOCK_GET_RESPONSE = 105;
+        CLIENT_BATCH_LIST_REQUEST = 106;
+        CLIENT_BATCH_LIST_RESPONSE = 107;
+        CLIENT_BATCH_GET_REQUEST = 108;
+        CLIENT_BATCH_GET_RESPONSE = 109;
+        CLIENT_TRANSACTION_LIST_REQUEST = 110;
+        CLIENT_TRANSACTION_LIST_RESPONSE = 111;
+        CLIENT_TRANSACTION_GET_REQUEST = 112;
+        CLIENT_TRANSACTION_GET_RESPONSE = 113;
+        // Client state request of the current state hash to be retrieved from the journal
+        CLIENT_STATE_CURRENT_REQUEST = 114;
+        // Response with the current state hash
+        CLIENT_STATE_CURRENT_RESPONSE = 115;
+        // A request of all the addresses under a particular prefix, for a state hash.
+        CLIENT_STATE_LIST_REQUEST = 116;
+        // The response of the addresses
+        CLIENT_STATE_LIST_RESPONSE = 117;
+        // Get the address:data entry at a particular address
+        CLIENT_STATE_GET_REQUEST = 118;
+        // The response with the entry
+        CLIENT_STATE_GET_RESPONSE = 119;
+        // A request for the status of a batch or batches
+        CLIENT_BATCH_STATUS_REQUEST = 120;
+        // A response with the batch statuses
+        CLIENT_BATCH_STATUS_RESPONSE = 121;
+        // A request for one or more transaction receipts
+        CLIENT_RECEIPT_GET_REQUEST = 122;
+        // A response with the receipts
+        CLIENT_RECEIPT_GET_RESPONSE = 123;
+        CLIENT_BLOCK_GET_BY_NUM_REQUEST = 124;
+        // A request for a validator's peers
+        CLIENT_PEERS_GET_REQUEST = 125;
+        // A response with the validator's peers
+        CLIENT_PEERS_GET_RESPONSE = 126;
+        CLIENT_BLOCK_GET_BY_TRANSACTION_ID_REQUEST = 127;
+        CLIENT_BLOCK_GET_BY_BATCH_ID_REQUEST = 128;
+        // A request for a validator's status
+        CLIENT_STATUS_GET_REQUEST = 129;
+        // A response with the validator's status
+        CLIENT_STATUS_GET_RESPONSE = 130;
+
+        // Message types for events
+        CLIENT_EVENTS_SUBSCRIBE_REQUEST = 500;
+        CLIENT_EVENTS_SUBSCRIBE_RESPONSE = 501;
+        CLIENT_EVENTS_UNSUBSCRIBE_REQUEST = 502;
+        CLIENT_EVENTS_UNSUBSCRIBE_RESPONSE = 503;
+        CLIENT_EVENTS = 504;
+        CLIENT_EVENTS_GET_REQUEST = 505;
+        CLIENT_EVENTS_GET_RESPONSE = 506;
+
+        // Temp message types until a discussion can be had about gossip msg
+        GOSSIP_MESSAGE = 200;
+        GOSSIP_REGISTER = 201;
+        GOSSIP_UNREGISTER = 202;
+        GOSSIP_BLOCK_REQUEST = 205;
+        GOSSIP_BLOCK_RESPONSE = 206;
+        GOSSIP_BATCH_BY_BATCH_ID_REQUEST = 207;
+        GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST = 208;
+        GOSSIP_BATCH_RESPONSE = 209;
+        GOSSIP_GET_PEERS_REQUEST = 210;
+        GOSSIP_GET_PEERS_RESPONSE = 211;
+        GOSSIP_CONSENSUS_MESSAGE = 212;
+
+        NETWORK_ACK = 300;
+        NETWORK_CONNECT = 301;
+        NETWORK_DISCONNECT = 302;
+
+        // Message types for Authorization Types
+        AUTHORIZATION_CONNECTION_RESPONSE = 600;
+        AUTHORIZATION_VIOLATION = 601;
+        AUTHORIZATION_TRUST_REQUEST = 602;
+        AUTHORIZATION_TRUST_RESPONSE = 603;
+        AUTHORIZATION_CHALLENGE_REQUEST = 604;
+        AUTHORIZATION_CHALLENGE_RESPONSE = 605;
+        AUTHORIZATION_CHALLENGE_SUBMIT = 606;
+        AUTHORIZATION_CHALLENGE_RESULT = 607;
+
+        PING_REQUEST = 700;
+        PING_RESPONSE = 701;
+
+        // Consensus service messages
+        CONSENSUS_REGISTER_REQUEST = 800;
+        CONSENSUS_REGISTER_RESPONSE = 801;
+
+        CONSENSUS_SEND_TO_REQUEST = 802;
+        CONSENSUS_SEND_TO_RESPONSE = 803;
+        CONSENSUS_BROADCAST_REQUEST = 804;
+        CONSENSUS_BROADCAST_RESPONSE = 805;
+
+        CONSENSUS_INITIALIZE_BLOCK_REQUEST = 806;
+        CONSENSUS_INITIALIZE_BLOCK_RESPONSE = 807;
+        CONSENSUS_FINALIZE_BLOCK_REQUEST = 808;
+        CONSENSUS_FINALIZE_BLOCK_RESPONSE = 809;
+        CONSENSUS_SUMMARIZE_BLOCK_REQUEST = 828;
+        CONSENSUS_SUMMARIZE_BLOCK_RESPONSE = 829;
+        CONSENSUS_CANCEL_BLOCK_REQUEST = 810;
+        CONSENSUS_CANCEL_BLOCK_RESPONSE = 811;
+
+        CONSENSUS_CHECK_BLOCKS_REQUEST = 812;
+        CONSENSUS_CHECK_BLOCKS_RESPONSE = 813;
+        CONSENSUS_COMMIT_BLOCK_REQUEST = 814;
+        CONSENSUS_COMMIT_BLOCK_RESPONSE = 815;
+        CONSENSUS_IGNORE_BLOCK_REQUEST = 816;
+        CONSENSUS_IGNORE_BLOCK_RESPONSE = 817;
+        CONSENSUS_FAIL_BLOCK_REQUEST = 818;
+        CONSENSUS_FAIL_BLOCK_RESPONSE = 819;
+
+        CONSENSUS_SETTINGS_GET_REQUEST = 820;
+        CONSENSUS_SETTINGS_GET_RESPONSE = 821;
+        CONSENSUS_STATE_GET_REQUEST = 822;
+        CONSENSUS_STATE_GET_RESPONSE = 823;
+        CONSENSUS_BLOCKS_GET_REQUEST = 824;
+        CONSENSUS_BLOCKS_GET_RESPONSE = 825;
+        CONSENSUS_CHAIN_HEAD_GET_REQUEST = 826;
+        CONSENSUS_CHAIN_HEAD_GET_RESPONSE = 827;
+
+        // Consensus notification messages
+        CONSENSUS_NOTIFY_PEER_CONNECTED = 900;
+        CONSENSUS_NOTIFY_PEER_DISCONNECTED = 901;
+        CONSENSUS_NOTIFY_PEER_MESSAGE = 902;
+
+        CONSENSUS_NOTIFY_BLOCK_NEW = 903;
+        CONSENSUS_NOTIFY_BLOCK_VALID = 904;
+        CONSENSUS_NOTIFY_BLOCK_INVALID = 905;
+        CONSENSUS_NOTIFY_BLOCK_COMMIT = 906;
+
+        CONSENSUS_NOTIFY_ENGINE_ACTIVATED = 907;
+        CONSENSUS_NOTIFY_ENGINE_DEACTIVATED = 908;
+
+        CONSENSUS_NOTIFY_ACK = 999;
+    }
+    // The type of message, used to determine how to 'route' the message
+    // to the appropriate handler as well as how to deserialize the
+    // content.
+    MessageType message_type = 1;
+
+    // The identifier used to correlate response messages to their related
+    // request messages.  correlation_id should be set to a random string
+    // for messages which are not responses to previously sent messages.  For
+    // response messages, correlation_id should be set to the same string as
+    // contained in the request message.
+    string correlation_id = 2;
+
+    // The content of the message, defined by message_type.  In many
+    // cases, this data has been serialized with Protocol Buffers or
+    // CBOR.
+    bytes content = 3;
+
+}

--- a/libs/sawtooth/scc/sawtooth.scc
+++ b/libs/sawtooth/scc/sawtooth.scc
@@ -1,0 +1,25 @@
+// serializable data structures used in RPC
+#include <suil/base/string.hpp>
+
+// Load library used to generate the meta types
+#pragma load sbg
+
+namespace suil::saw::Client {
+
+    struct [[gen::sbg(meta)]] WalletEntry {
+#pragma native
+        WalletEntry() = default;
+        WalletEntry(String name, String key)
+            : Name{std::move(name)},
+              Key{std::move(key)}
+        {}
+#pragma endnative
+        String Name{""};
+        String Key{""};
+    };
+
+    struct [[gen::sbg(meta)]] WalletSchema {
+        String MasterKey;
+        std::vector<WalletEntry> Keys;
+    };
+}

--- a/libs/sawtooth/src/address.cpp
+++ b/libs/sawtooth/src/address.cpp
@@ -2,7 +2,7 @@
 // Created by Mpho Mbotho on 2021-06-04.
 //
 
-#include "suil/sawtooth/address.hpp"
+#include <suil/sawtooth/address.hpp>
 
 #include <suil/base/hash.hpp>
 

--- a/libs/sawtooth/src/address.cpp
+++ b/libs/sawtooth/src/address.cpp
@@ -1,0 +1,78 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include "suil/sawtooth/address.hpp"
+
+#include <suil/base/hash.hpp>
+
+namespace suil::saw {
+
+    void DefaultAddressEncoder::isValidAddr(const String& addr)
+    {
+        if (addr.size() != ADDRESS_LENGTH) {
+            throw AddressEncodeError("Address size is invalid, {Expected: ",
+                                    ADDRESS_LENGTH, ", Got: ", addr.size(), "}");
+        }
+        else if (!addr.ishex()) {
+            throw AddressEncodeError("Address must be lowercase hexadecimal ONLY");
+        }
+    }
+
+    void DefaultAddressEncoder::isNamespaceValid(const suil::String& ns)
+    {
+        if (ns.size() != NS_PREFIX_LENGTH) {
+            throw AddressEncodeError("Namespace size is invalid, {Expected: ",
+                                    NS_PREFIX_LENGTH, ", Got: ", ns.size(), "}");
+        }
+        else if (!ns.ishex()) {
+            throw AddressEncodeError("Namespace prefix must be lowercase hexadecimal ONLY");
+        }
+    }
+
+    DefaultAddressEncoder::DefaultAddressEncoder(const suil::String &ns)
+            : mNamespace(ns.dup())
+    {}
+
+    DefaultAddressEncoder::DefaultAddressEncoder(DefaultAddressEncoder &&other) noexcept
+        : mNamespace(std::move(other.mNamespace)),
+          mPrefix(std::move(other.mPrefix))
+    {}
+
+    DefaultAddressEncoder& DefaultAddressEncoder::operator=(DefaultAddressEncoder &&other) noexcept
+    {
+        if (this != &other) {
+            Ego.mNamespace = std::move(other.mNamespace);
+            Ego.mPrefix = std::move(other.mPrefix);
+        }
+        return Ego;
+    }
+
+    suil::String DefaultAddressEncoder::mapNamespace(const suil::String &ns) const
+    {
+        return suil::SHA512(ns).substr(0, NS_PREFIX_LENGTH, false);
+    }
+
+    suil::String DefaultAddressEncoder::mapKey(const suil::String &key)
+    {
+        return suil::SHA512(key).substr(NS_PREFIX_LENGTH, ADDRESS_LENGTH-NS_PREFIX_LENGTH, false);
+    }
+
+    const suil::String& DefaultAddressEncoder::getPrefix()
+    {
+        if (Ego.mPrefix.empty()) {
+            Ego.mPrefix = Ego.mapNamespace(Ego.mNamespace);
+            isNamespaceValid(Ego.mPrefix);
+        }
+        return Ego.mPrefix;
+    }
+
+    suil::String DefaultAddressEncoder::operator()(const suil::String &key)
+    {
+        auto addr = suil::catstr(Ego.getPrefix(), Ego.mapKey(key));
+        isValidAddr(addr);
+        return addr;
+    }
+
+
+}

--- a/libs/sawtooth/src/client.cpp
+++ b/libs/sawtooth/src/client.cpp
@@ -1,0 +1,248 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include "suil/sawtooth/client.hpp"
+#include "suil/sawtooth/transaction.hpp"
+
+#include <suil/base/buffer.hpp>
+#include <suil/base/crypto.hpp>
+#include <suil/base/uuid.hpp>
+
+namespace sp = sawtooth::protos;
+
+namespace suil::saw::Client {
+
+
+    Signer::Signer(secp256k1::KeyPair&& key)
+            : mKey(key)
+    {}
+
+    Signer:: Signer(Signer&& other) noexcept
+            : mKey(other.mKey)
+    {}
+
+    Signer& Signer::operator=(Signer&& other) noexcept
+    {
+        Ego.mKey = other.mKey;
+        return Ego;
+    }
+
+    Signer Signer::load(const suil::String& privKey)
+    {
+        auto priv = secp256k1::PrivateKey::fromString(privKey);
+        if (!priv.isnil()) {
+            return Signer::load(priv);
+        }
+        else {
+            return Signer{{}};
+        }
+    }
+
+    Signer Signer::load(const secp256k1::PrivateKey& privKey)
+    {
+        return Signer{secp256k1::KeyPair::fromPrivateKey(privKey)};
+    }
+
+    void Signer::get(secp256k1::PrivateKey& out) const
+    {
+        if (Ego.isValid()) {
+            out.copyfrom(Ego.getPrivateKey());
+        }
+    }
+
+    void Signer::get(secp256k1::PublicKey& out) const {
+        if (Ego.isValid()) {
+            out.copyfrom(Ego.getPublicKey());
+        }
+    }
+
+    const secp256k1::PrivateKey& Signer::getPrivateKey() const {
+        return Ego.mKey.Private;
+    }
+
+    const secp256k1::PublicKey& Signer::getPublicKey() const {
+        return Ego.mKey.Public;
+    }
+
+    suil::String Signer::sign(const void* data, size_t len) const {
+        secp256k1::Signature signature;
+        if (secp256k1::ECDSASign(signature, Ego.getPrivateKey(), data, len)) {
+            return signature.toString();
+        }
+        ierror("Signer::sign signing message failed");
+        return {};
+    }
+
+    bool Signer::verify(const void* data, size_t len, const suil::String& sig, const suil::String& publicKey)
+    {
+        LOGGER(SAWSDK_CLIENT) lt;
+        auto signature = secp256k1::Signature::fromCompact(sig);
+        if (signature.isnil()) {
+            lerror(&lt, "Signer::verify loading signature failed");
+            return false;
+        }
+        auto pubKey = secp256k1::PublicKey::fromString(publicKey);
+        if (pubKey.isnil()) {
+            lerror(&lt, "Signer::verify loading public key failed");
+            return false;
+        }
+        return secp256k1::ECDSAVerify(data, len, signature, pubKey);
+    }
+
+    Transaction::Transaction()
+            : mSelf(new sawtooth::protos::Transaction)
+    {}
+
+    sp::Transaction& Transaction::get() {
+        return *mSelf;
+    }
+
+    sawtooth::protos::Transaction& Transaction::operator*() {
+        return *mSelf;
+    }
+
+    sawtooth::protos::Transaction* Transaction::operator->() {
+        return Ego.mSelf.get();
+    }
+
+    const sawtooth::protos::Transaction& Transaction::operator*() const {
+        return *mSelf;
+    }
+
+    const sawtooth::protos::Transaction* Transaction::operator->() const {
+        return Ego.mSelf.get();
+    }
+
+
+    Batch::Batch()
+            : mSelf(new sp::Batch)
+    {}
+
+    sawtooth::protos::Batch& Batch::get() {
+        return *mSelf;
+    }
+
+    sawtooth::protos::Batch* Batch::operator->() {
+        return Ego.mSelf.get();
+    }
+
+    sawtooth::protos::Batch& Batch::operator*() {
+        return *mSelf;
+    }
+
+    const sawtooth::protos::Batch* Batch::operator->() const {
+        return Ego.mSelf.get();
+    }
+
+    const sawtooth::protos::Batch& Batch::operator*() const {
+        return *mSelf;
+    }
+
+    Encoder::Encoder(const String& family, String&& familyVersion, const String&& privateKey)
+        : mSigner{Signer::load(privateKey)},
+          mBatcher{Signer::load(privateKey)},
+          mFamily{family.dup()},
+          mFamilyVersion{std::move(familyVersion)}
+    {
+        mBatcherPublicKey = mSigner.getPublicKey().toString();
+        mSignerPublicKey = mBatcher.getPublicKey().toString();
+    }
+
+    void Encoder::setBatcher(const suil::String &key)
+    {
+        Ego.mBatcher = Signer::load(key);
+        if (!Ego.mBatcher.isValid()) {
+            throw EncoderError("Given batcher '", key, "' is an invalid key");
+        }
+        Ego.mBatcherPublicKey = mBatcher.getPublicKey().toString();
+    }
+
+    void Encoder::setSigner(const suil::String &key)
+    {
+        Ego.mSigner = Signer::load(key);
+        if (!Ego.mSigner.isValid()) {
+            throw EncoderError("Given signer '", key, "' is an invalid key");
+        }
+        Ego.mSignerPublicKey = mSigner.getPublicKey().toString();
+    }
+
+    Transaction Encoder::operator()(const suil::Data& payload, const Inputs& inputs, const Outputs& outputs) const
+    {
+        crypto::SHA512Digest sha512;
+        crypto::SHA512(sha512, payload);
+
+        sp::TransactionHeader header;
+        protoSet(header, family_name, Ego.mFamily);
+        protoSet(header, family_version, Ego.mFamilyVersion);
+        protoSet(header, signer_public_key, Ego.mSignerPublicKey);
+        protoSet(header, batcher_public_key, Ego.mBatcherPublicKey);
+        protoSet(header, nonce, suil::uuidstr());
+        protoSet(header, payload_sha512, sha512.toString());
+        for (const auto& input: inputs) {
+            protoAdd(header, inputs, input);
+        }
+        for (const auto& output: outputs) {
+            protoAdd(header, outputs, output);
+        }
+        auto headerBytes = protoSerialize(header);
+        auto signature = Ego.mSigner.sign(headerBytes);
+
+        Transaction txn;
+        protoSet(*txn, payload, payload);
+        protoSet(*txn, header, headerBytes);
+        protoSet(*txn, header_signature, signature);
+        return txn;
+    }
+
+    Batch Encoder::operator()(const std::vector<Transaction> &txns) const
+    {
+        sp::BatchHeader header;
+        Batch batch;
+        for (const auto& txn: txns) {
+            protoAdd(header, transaction_ids, txn->header_signature());
+            auto it = batch->add_transactions();
+            it->CopyFrom(*txn);
+        }
+        protoSet(header, signer_public_key, Ego.mBatcherPublicKey);
+
+        auto headerBytes = protoSerialize(header);
+        auto signature = mBatcher.sign(headerBytes);
+        protoSet(*batch, header, headerBytes);
+        protoSet(*batch, header_signature, signature);
+        protoSet(*batch, trace, true);
+        return batch;
+    }
+
+    void Encoder::encode(sawtooth::protos::BatchList& out, const std::vector<Batch>& batches) {
+        for (const auto& batch: batches) {
+            out.add_batches()->CopyFrom(*batch);
+        }
+    }
+
+    suil::Data Encoder::encode(const std::vector<Batch> &batches)
+    {
+        sawtooth::protos::BatchList list;
+        Encoder::encode(list, batches);
+        suil::Data data{list.ByteSizeLong()};
+        list.SerializeToArray(data.data(), static_cast<int>(data.size()));
+        return data;
+    }
+
+    void Encoder::encode(Buffer& dst, const std::vector<Batch> &batches)
+    {
+        sawtooth::protos::BatchList list;
+        Encoder::encode(list, batches);
+        dst.reserve(list.ByteSizeLong()+16);
+        auto buf = &dst[dst.size()];
+        list.SerializeToArray(buf, static_cast<int>(dst.capacity()));
+        dst.seek(list.ByteSizeLong()+5);
+    }
+
+    Batch Encoder::encode(const suil::Data &payload, const Inputs &inputs, const Outputs &outputs)
+    {
+        auto txn = Ego(payload, inputs, outputs);
+        return Ego(txn);
+    }
+
+}

--- a/libs/sawtooth/src/dispatcher.cpp
+++ b/libs/sawtooth/src/dispatcher.cpp
@@ -1,0 +1,156 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include "suil/sawtooth/dispatcher.hpp"
+
+namespace suil::saw {
+
+    const suil::String Dispatcher::DISPATCH_THREAD_ENDPOINT{"inproc://dispatch_thread"};
+    const suil::String Dispatcher::SERVER_MONITOR_ENDPOINT{"inproc://server_monitor"};
+    const suil::String Dispatcher::EXIT_MESSAGE{"Exit"};
+
+    Dispatcher::Dispatcher(net::zmq::Context& ctx)
+        : mContext{ctx},
+          mServerSock{mContext},
+          mMsgSock{mContext},
+          mRequestSock{mContext},
+          mDispatchSock{mContext}
+    {
+        Ego.mMsgSock.bind("inproc://send_queue");
+        Ego.mRequestSock.bind("inproc://request_queue");
+        Ego.mDispatchSock.bind(DISPATCH_THREAD_ENDPOINT);
+    }
+
+    Stream Dispatcher::createStream()
+    {
+        return Stream{Ego.mContext, Ego.mOnAirMessages};
+    }
+
+    void Dispatcher::connect(const suil::String &connString)
+    {
+        iinfo("Dispatcher connecting to %s", connString());
+        bool status{false};
+        try {
+            status = Ego.mServerSock.connect(connString);
+        }
+        catch (...) {
+            auto ex = Exception::fromCurrent();
+            ierror("Connecting to server failed: %s", ex.what());
+            throw;
+        }
+
+        if (!status) {
+            ierror("Connecting to server failed: %s", zmq_strerror(zmq_errno()));
+            throw DispatcherError("Connecting to server failed: ", zmq_strerror(zmq_errno()));
+        }
+
+        go(sendMessages(Ego));
+        go(exitMonitor(Ego));
+        go(receiveMessages(Ego));
+    }
+
+    void Dispatcher::disconnect()
+    {
+        iinfo("Disconnecting server socket");
+        Ego.mServerSock.close();
+    }
+
+    void Dispatcher::exit()
+    {
+        idebug("dispatcher exiting...");
+        Ego.mDispatchSock.send(Dispatcher::EXIT_MESSAGE);
+    }
+
+    void Dispatcher::receiveMessages(Dispatcher &Self)
+    {
+        ldebug(&Self, "starting receiveMessages coroutine");
+        while (!Self.mExiting) {
+            net::zmq::Message zmsg{};
+            if (!Self.mServerSock.receive(zmsg) || zmsg.empty() || zmsg.back().empty()) {
+                ldebug(&Self, "receivedMessages - ignoring empty message");
+                continue;
+            }
+
+            Message::UPtr proto(Message::mkunique());
+            auto& frame = zmsg.back();
+            proto->ParseFromArray(frame.data(), static_cast<int>(frame.size()));
+            ltrace(&Self, "received message {type: %d}", proto->message_type());
+
+            switch (proto->message_type()) {
+                case sawtooth::protos::Message_MessageType_TP_PROCESS_REQUEST: {
+                    Self.mRequestSock.send(zmsg);
+                    break;
+                }
+                case sawtooth::protos::Message_MessageType_PING_REQUEST: {
+                    ltrace(&Self, "Received ping request with correlation %s", proto->correlation_id().data());
+                    sawtooth::protos::PingResponse resp;
+                    suil::Data data{resp.ByteSizeLong()};
+                    resp.SerializeToArray(data.data(), static_cast<int>(data.size()));
+
+                    sawtooth::protos::Message msg;
+                    msg.set_correlation_id(proto->correlation_id());
+                    msg.set_message_type(sawtooth::protos::Message_MessageType_PING_RESPONSE);
+                    msg.set_content(data.cdata(), data.size());
+                    suil::Data rdata{msg.ByteSizeLong()};
+                    msg.SerializeToArray(rdata.data(), static_cast<int>(rdata.size()));
+                    Self.mServerSock.send(rdata);
+                    break;
+                }
+                default: {
+                    String cid{proto->correlation_id(), false};
+                    auto it = Self.mOnAirMessages.find(cid);
+                    if (it != Self.mOnAirMessages.end()) {
+                        it->second->setMessage(std::move(proto));
+                        Self.mOnAirMessages.erase(it);
+                    }
+                    else {
+                        ldebug(&Self, "Received a message with no matching correlation %s", cid());
+                    }
+                }
+            }
+        }
+        ldebug(&Self, "receive messages coroutine exit");
+    }
+
+    void Dispatcher::sendMessages(Dispatcher &Self)
+    {
+        ldebug(&Self, "Starting sendMessages coroutine");
+        while (!Self.mExiting) {
+            net::zmq::Message msg{};
+            if (!Self.mMsgSock.receive(msg) || msg.empty()) {
+                ldebug(&Self, "sendMessages - ignoring empty message");
+                continue;
+            }
+
+            if (!Self.mServerSock.isConnected()) {
+                ldebug(&Self, "sendMessages - server is not connected, dropping message");
+                continue;
+            }
+
+            Self.mServerSock.send(msg);
+        }
+        ldebug(&Self, "Exiting sendMessages coroutines");
+    }
+
+    void Dispatcher::exitMonitor(Dispatcher &Self)
+    {
+        ldebug(&Self, "Starting exitMonitor coroutine");
+        net::zmq::PairSocket sock(Self.mContext);
+        sock.connect(Dispatcher::DISPATCH_THREAD_ENDPOINT);
+
+        while (!Self.mExiting) {
+            net::zmq::Message msg{};
+            if (!sock.receive(msg) || msg.empty() || msg.back().empty()) {
+                Self.mExiting = true;
+                continue;
+            }
+            String what{static_cast<const char*>(msg.back().data()), msg.back().size(), false};
+            Self.mExiting = (what == EXIT_MESSAGE);
+        }
+        Self.mServerSock.close();
+        Self.mMsgSock.close();
+        ldebug(&Self, "Exiting exitMonitor coroutine");
+    }
+
+}

--- a/libs/sawtooth/src/events.cpp
+++ b/libs/sawtooth/src/events.cpp
@@ -1,0 +1,205 @@
+//
+// Created by Mpho Mbotho on 2021-06-30.
+//
+
+
+#include <suil/sawtooth/events.hpp>
+#include <suil/sawtooth/transaction.hpp>
+
+
+#include <suil/base/uuid.hpp>
+
+namespace sp {
+    using namespace sawtooth::protos;
+    constexpr auto CLIENT_EVENTS_SUBSCRIBE_RESPONSE{Message_MessageType_CLIENT_EVENTS_SUBSCRIBE_RESPONSE};
+    constexpr auto CLIENT_EVENTS_SUBSCRIBE_REQUEST{Message_MessageType_CLIENT_EVENTS_SUBSCRIBE_REQUEST};
+    constexpr auto CLIENT_EVENTS_UNSUBSCRIBE_RESPONSE{Message_MessageType_CLIENT_EVENTS_UNSUBSCRIBE_RESPONSE};
+    constexpr auto CLIENT_EVENTS_UNSUBSCRIBE_REQUEST{Message_MessageType_CLIENT_EVENTS_UNSUBSCRIBE_REQUEST};
+}
+
+namespace suil::saw {
+
+    static std::string correlationId()
+    {
+        static std::uint64_t sId;
+        return std::to_string(sId++);
+    }
+
+    Filter::Filter(String key, String matchString, sp::EventFilter_FilterType filterType)
+        : mEventFilter{}
+    {
+        protoSet(mEventFilter, key, key);
+        protoSet(mEventFilter, match_string, matchString);
+        protoSet(mEventFilter, filter_type, filterType);
+    }
+
+    template <typename Type>
+    static void send(net::zmq::DealerSocket& sock, Data payload, const String& tag, Type type)
+    {
+        sp::Message msg;
+        protoSet(msg, message_type, type);
+        protoSet(msg, content, payload);
+        protoSet(msg, correlation_id, correlationId());
+
+        payload = Data{msg.ByteSizeLong()};
+        msg.SerializeToArray(payload.data(), int(payload.size()));
+
+        if (!sock.send(payload)) {
+            throw EventSubscriptionError(AnT(),
+                                         "Sending ", tag, " request to server failed");
+        }
+    }
+
+    EventSubscription::EventSubscription(net::zmq::Context& context, String url)
+        : mCtx(context),
+          mSock(context),
+          mId(suil::uuidstr())
+    {
+        if (!mSock.connect(url)) {
+            throw EventSubscriptionError("Connecting to URL '", url, "' failed");
+        }
+    }
+
+    void EventSubscription::subscribe(const String& eventType, std::vector<Filter> filters)
+    {
+        if (mHandler) {
+            throw EventSubscriptionError(AnT(),
+                    "Cannot send subscribe request when waiting for events. (Might support in the future)");
+        }
+
+        sp::EventSubscription subscription;
+        protoSet(subscription, event_type, eventType);
+        for (auto& filter: filters) {
+            auto sf = subscription.add_filters();
+            sf->CopyFrom(filter());
+        }
+
+        sp::ClientEventsSubscribeRequest req;
+        req.add_subscriptions()->CopyFrom(subscription);
+        suil::Data data{req.ByteSizeLong()};
+        req.SerializeToArray(data.data(), static_cast<int>(data.size()));
+
+        sendSubscription(std::move(data));
+    }
+
+    void EventSubscription::sendSubscription(suil::Data payload)
+    {
+        send(mSock,
+             std::move(payload),
+             "subscribe",
+             sp::CLIENT_EVENTS_SUBSCRIBE_REQUEST);
+
+        net::zmq::Message zMsg{};
+        if (!mSock.receive(zMsg)) {
+            throw EventSubscriptionError(AnT(),
+                                         "receiving response to subscribe request failed");
+        }
+
+        if (zMsg.empty() || zMsg.back().empty()) {
+            throw EventSubscriptionError(AnT(),
+                                         "received invalid response to subscribe request");
+        }
+
+        auto& frame = zMsg.back();
+        sp::Message respMsg;
+        respMsg.ParseFromArray(frame.data(), int(frame.size()));
+        if (respMsg.message_type() != sp::CLIENT_EVENTS_SUBSCRIBE_RESPONSE) {
+            throw EventSubscriptionError(AnT(),
+                                         "Unexpected response type (",
+                                         respMsg.message_type(),
+                                         ") while waiting for CLIENT_EVENTS_SUBSCRIBE_RESPONSE");
+        }
+
+        sp::ClientEventsSubscribeResponse resp;
+        resp.ParseFromString(respMsg.content());
+        if (resp.status() != sp::ClientEventsSubscribeResponse_Status_OK) {
+            throw EventSubscriptionError(AnT(),
+                                         "subscribe request rejected: ", resp.response_message());
+        }
+    }
+
+    void EventSubscription::sendCancelSubscription()
+    {
+        sp::ClientEventsUnsubscribeRequest unsub;
+        Data payload{unsub.ByteSizeLong()};
+        unsub.SerializeToArray(payload.data(), int(payload.size()));
+
+        send(mSock,
+             std::move(payload),
+             "unsubscribe", sp::CLIENT_EVENTS_UNSUBSCRIBE_REQUEST);
+
+        // Wait maximum of 2 seconds for response
+        if (!mCancelWait.wait(Deadline{2000})) {
+            ierror("EventSubscription(" PRIs ") - timed out while waiting for unsubscribe response");
+        }
+    }
+
+    void EventSubscription::operator()(Handler handler)
+    {
+        if (!mSock.isConnected() || mHandler) {
+            throw EventSubscriptionError(AnT(),
+                                 "Current event subscription cannot be started: ",
+                                         (mHandler? "already started": "not connected"));
+        }
+        if (handler == nullptr) {
+            throw EventSubscriptionError(AnT(),
+                                         "handler cannot be null");
+        }
+        Ego.mHandler = std::move(handler);
+        go(receiveEventsAsync(Ego));
+    }
+
+    void EventSubscription::receiveEventsAsync(EventSubscription& S)
+    {
+        ldebug(&S, "EventSubscription(" PRIs ") - starting receive events async", _PRIs(S.mId));
+        while (S.mSock.isConnected()) {
+            net::zmq::Message zMsg;
+            if (!S.mSock.receive(zMsg) or zMsg.empty() or zMsg.back().empty()) {
+                // maybe aborted
+                continue;
+            }
+
+            auto& frame = zMsg.back();
+            sp::Message msg;
+            if (!msg.ParseFromArray(frame.data(), int(frame.size()))) {
+                lerror(&S, "EventSubscription: parsing received frame failed");
+                continue;
+            }
+
+            if (msg.message_type() == sp::Message_MessageType_CLIENT_EVENTS_UNSUBSCRIBE_RESPONSE) {
+                // unsubscribe was sent to server, break out of loop immediately
+                ldebug(&S, "EventSubscription(" PRIs ") - received unsubscribe response, aborting", _PRIs(S.mId));
+                S.mCancelWait.notifyOne();
+                break;
+            }
+
+            if (msg.message_type() != sp::Message_MessageType_CLIENT_EVENTS) {
+                lerror(&S, "EventSubscription(" PRIs ") - unexpected message {type: %d}, expecting CLIENT_EVENTS",
+                            _PRIs(S.mId), int(msg.message_type()));
+                continue;
+            }
+
+            sp::EventList eventList;
+            eventList.ParseFromString(msg.content());
+            for (auto& event: eventList.events()) {
+                S.mHandler(event);
+            }
+        }
+
+        ldebug(&S, "EventSubscription(" PRIs ") - receive events async done ", _PRIs(S.mId));
+    }
+
+    void EventSubscription::close()
+    {
+        if (mSock.isConnected() and mHandler) {
+            // send cancellation
+            Ego.sendCancelSubscription();
+            mSock.close();
+        }
+    }
+
+    EventSubscription::~EventSubscription()
+    {
+        close();
+    }
+}

--- a/libs/sawtooth/src/gstate.cpp
+++ b/libs/sawtooth/src/gstate.cpp
@@ -1,0 +1,159 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include "suil/sawtooth/gstate.hpp"
+
+#include "suil/sawtooth/transaction.hpp"
+
+namespace sp {
+    using sawtooth::protos::Message;
+    using sawtooth::protos::TpStateGetRequest;
+    using sawtooth::protos::TpStateGetResponse;
+    using sawtooth::protos::TpStateSetRequest;
+    using sawtooth::protos::TpStateSetResponse;
+    using sawtooth::protos::TpStateDeleteRequest;
+    using sawtooth::protos::TpStateDeleteResponse;
+    using sawtooth::protos::TpEventAddRequest;
+    using sawtooth::protos::TpEventAddResponse;
+    using sawtooth::protos::TpStateEntry;
+    using sawtooth::protos::Event;
+    using sawtooth::protos::EventFilter;
+    using sawtooth::protos::Event_Attribute;
+}
+
+namespace suil::saw {
+
+    GlobalState::GlobalState(Stream &&stream, const suil::String &contextId)
+        : mStream{std::move(stream)},
+          mContextId{contextId.dup()}
+    {}
+
+    GlobalState::GlobalState(GlobalState &&other)
+        :  mStream(std::move(other.mStream)),
+           mContextId(std::move(other.mContextId))
+    {}
+
+    GlobalState& GlobalState::operator=(GlobalState &&other)
+    {
+        if (this != &other) {
+            Ego.mStream = std::move(other.mStream);
+            Ego.mContextId = std::move(other.mContextId);
+        }
+        return Ego;
+    }
+
+    Data GlobalState::getState(const String &address)
+    {
+        std::vector<String> addresses = {address.peek()};
+        UnorderedMap<Data> out{};
+        Ego.getState(out, addresses);
+        if (!out.empty()) {
+            return std::move(out.begin()->second);
+        }
+        return {};
+
+    }
+
+    void GlobalState::getState(UnorderedMap<Data>& data, const std::vector<String> &addresses)
+    {
+        data.clear();
+
+        sp::TpStateGetRequest req;
+        sp::TpStateGetResponse resp;
+
+        setValue(req, &sp::TpStateGetRequest::set_context_id, Ego.mContextId);
+        for(const auto& addr: addresses) {
+            setValue(req, &sp::TpStateGetRequest::add_addresses, addr);
+        }
+        auto future = Ego.mStream.asyncSend(sp::Message::TP_STATE_GET_REQUEST, req);
+        future->getMessage(resp, sp::Message::TP_STATE_GET_RESPONSE);
+
+        if (resp.status() == sp::TpStateGetResponse::AUTHORIZATION_ERROR) {
+            throw GlobalStateError("Global globalState get authorization error - Check transaction inputs");
+        }
+
+        if (resp.entries_size() > 0) {
+            for (const auto& entry: resp.entries()) {
+                data.emplace(String{entry.address(), true}, fromStdString(entry.data()).copy());
+            }
+        }
+    }
+
+    void GlobalState::setState(const suil::String &address, const suil::Data &value)
+    {
+        std::vector<GlobalState::KeyValue> data = {{address.peek(), value.peek()}};
+        Ego.setState(data);
+    }
+
+    void GlobalState::setState(const std::vector<GlobalState::KeyValue> &data)
+    {
+        sp::TpStateSetRequest req;
+        sp::TpStateSetResponse resp;
+
+        setValue(req, &sp::TpStateSetRequest::set_context_id, Ego.mContextId);
+        for (const auto& [first, second]: data) {
+            auto& entry = *req.add_entries();
+            setValue(entry, &sp::TpStateEntry::set_address, first);
+            entry.set_data(second.cdata(), second.size());
+        }
+
+        auto future = Ego.mStream.asyncSend(sp::Message::TP_STATE_SET_REQUEST, req);
+        future->getMessage(resp, sp::Message::TP_STATE_SET_RESPONSE);
+        if (resp.status() == sp::TpStateSetResponse::AUTHORIZATION_ERROR) {
+            throw GlobalStateError("Set global globalState authorization error - check inputs");
+        }
+    }
+
+    void GlobalState::deleteState(const suil::String &address)
+    {
+        std::vector<suil::String> addresses{address.peek()};
+        Ego.deleteState(addresses);
+    }
+
+    void GlobalState::deleteState(const std::vector<suil::String> &addresses)
+    {
+        sp::TpStateDeleteRequest req;
+        sp::TpStateDeleteResponse resp;
+
+        setValue(req, &sp::TpStateDeleteRequest::set_context_id, Ego.mContextId);
+        for (const auto& addr: addresses) {
+            setValue(req, &sp::TpStateDeleteRequest::add_addresses, addr);
+        }
+
+        auto future = Ego.mStream.asyncSend(sp::Message::TP_STATE_DELETE_REQUEST, req);
+        future->getMessage(resp, sp::Message::TP_STATE_DELETE_RESPONSE);
+
+        if (resp.status() == sp::TpStateDeleteResponse::AUTHORIZATION_ERROR) {
+            throw GlobalStateError("global globalState authorization error - check transaction inputs");
+        }
+    }
+
+    void GlobalState::addEvent(
+            const suil::String &eventType,
+            const std::vector<GlobalState::KeyValue> &values,
+            const suil::Data &data)
+    {
+        sp::Event *event{new sp::Event};
+        setValue(*event, &sp::Event::set_event_type, eventType);
+        for (const auto& [first, second] : values) {
+            auto attr = *event->add_attributes();
+            setValue(attr, &sp::Event_Attribute::set_key, first);
+            setValue(attr, &sp::Event_Attribute::set_value, second);
+        }
+        event->set_data(data.cdata(), data.size());
+
+        sp::TpEventAddRequest req;
+        sp::TpEventAddResponse resp;
+
+        setValue(req, &sp::TpEventAddRequest::set_context_id, Ego.mContextId);
+        req.set_allocated_event(event);
+        auto future = Ego.mStream.asyncSend(sp::Message::TP_EVENT_ADD_REQUEST, req);
+        future->getMessage(resp, sp::Message::TP_EVENT_ADD_RESPONSE);
+
+        if (resp.status() == sp::TpEventAddResponse::ERROR) {
+            throw GlobalStateError("failed to add event {type: ", eventType, "}");
+        }
+    }
+
+}

--- a/libs/sawtooth/src/message.cpp
+++ b/libs/sawtooth/src/message.cpp
@@ -1,0 +1,55 @@
+//
+// Created by Mpho Mbotho on 2021-05-07.
+//
+
+#include "suil/sawtooth/message.hpp"
+
+namespace suil::saw {
+
+    OnAirMessage::OnAirMessage(suil::String cid)
+        : mCorrelationId(std::move(cid))
+    {}
+
+    OnAirMessage::OnAirMessage(OnAirMessage&& other) noexcept
+        : mMessage{std::move(other.mMessage)},
+          mCorrelationId{std::move(other.mCorrelationId)},
+          mSync{std::move(other.mSync)}
+    {}
+
+    OnAirMessage& OnAirMessage::operator=(OnAirMessage&& other) noexcept
+    {
+        if (this != &other) {
+            mCorrelationId = std::move(other.mCorrelationId);
+            mSync = std::move(other.mSync);
+            mMessage = std::move(other.mMessage);
+        }
+        return Ego;
+    }
+
+    OnAirMessage::~OnAirMessage()
+    {
+        // notify waiters if any
+        Ego.mSync.notify();
+    }
+
+    void OnAirMessage::waitForMessage(Message::Type type)
+    {
+        if (mMessage == nullptr) {
+            mSync.wait();
+            if (mMessage == nullptr) {
+                throw UnexpectedMessage("No message was received");
+            }
+        }
+
+        if (mMessage->message_type() != type) {
+            throw UnexpectedMessage("Unexpected response message type, expecting: ",
+                                    type, ", got: ", mMessage->message_type());
+        }
+    }
+
+    void OnAirMessage::setMessage(Message::UPtr&& message)
+    {
+        Ego.mMessage = std::move(message);
+        mSync.notify();
+    }
+}

--- a/libs/sawtooth/src/processor.cpp
+++ b/libs/sawtooth/src/processor.cpp
@@ -1,0 +1,9 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include <suil/sawtooth/processor.hpp>
+
+namespace suil::saw {
+
+}

--- a/libs/sawtooth/src/rest.cpp
+++ b/libs/sawtooth/src/rest.cpp
@@ -1,0 +1,152 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include "suil/sawtooth/rest.hpp"
+
+#include <suil/base/base64.hpp>
+
+namespace suil::saw::Client {
+
+    const char* RestApi::BATCHES_RESOURCE{"/batches"};
+    const char* RestApi::STATE_RESOURCE{"/state"};
+    const char* RestApi::BATCH_STATUSES{"/batch_statuses"};
+
+    RestApi::RestApi(
+            const suil::String &url,
+            const suil::String &family,
+            const suil::String &familyVersion,
+            const suil::String &privateKey, int port)
+        : mEncoder{family, familyVersion.dup(), privateKey.dup()},
+          mAddressEncoder{family},
+          mSession(http::cli::loadSession(url, port, {}))
+    {}
+
+    Return<String> RestApi::asyncBatches(const Data &payload, const Inputs& inputs, const Outputs& outputs)
+    {
+        std::vector<Batch> batches;
+        batches.push_back(Ego.mEncoder.encode(payload, inputs, outputs));
+        return Ego.asyncBatches(batches);
+    }
+
+    Return<String> RestApi::asyncBatches(const std::vector<Batch> &batches)
+    {
+        return TryCatch<String>([&]() -> Return<String> {
+            auto resp = http::cli::post(mSession, BATCHES_RESOURCE, [batches](http::cli::Request& req) {
+                Encoder::encode(req("application/octet-stream"), batches);
+                return true;
+            });
+
+            auto body = resp.str();
+            if (resp.status() == http::Status::Accepted) {
+                auto obj = json::Object::decode(body);
+                auto link = ((String) obj("link"));
+                auto start = link.find('=') + 1;
+                return link.substr(start).dup();
+            }
+            else {
+                return http::HttpError{resp.status(), body};
+            }
+        });
+    }
+
+    Return<Data> RestApi::getState(const suil::String &key, bool encode)
+    {
+        auto resource = suil::catstr(STATE_RESOURCE, "/", (encode? mAddressEncoder(key): key));
+        auto resp = http::cli::get(mSession, resource);
+        return TryCatch<Data>([&]() -> Return<Data> {
+            auto body = resp.str();
+            if (resp.status() == http::Status::Ok) {
+                auto res = json::Object::decode(body);
+                auto data = (String) res("data");
+                Buffer ob;
+                Base64::decode(ob, (const uint8_t*) data.data(), data.size());
+                return Data(ob.release(), ob.size(), true);
+            }
+            else {
+                return http::HttpError(resp.status(), body);
+            }
+        });
+    }
+
+    Return<std::vector<suil::Data>> RestApi::getStates(const suil::String &prefix)
+    {
+        return TryCatch<std::vector<suil::Data>>([&]() -> Return<std::vector<suil::Data>> {
+            auto resource = suil::catstr(STATE_RESOURCE, "?address=", prefix);
+            auto resp = http::cli::get(mSession, resource());
+            auto body = resp.str();
+            if (resp.status() == http::Status::Ok) {
+                auto res = json::Object::decode(body);
+                auto data = res("data");
+                std::vector<suil::Data> out;
+                for (auto&[_, obj] : data) {
+                    Buffer ob;
+                    auto entry = (String) obj("data");
+                    Base64::decode(ob, (const uint8_t*) entry.data(), entry.size());
+                    out.emplace_back(ob.release(), ob.size(), true);
+                }
+                return {std::move(out)};
+            } else {
+                return http::HttpError{resp.status(), std::move(body)};
+            }
+        });
+    }
+
+    suil::String RestApi::getPrefix()
+    {
+        return Ego.mAddressEncoder.getPrefix().peek();
+    }
+
+    Return<String> RestApi::getBatchStatus(const String& batchId, uint64 wait)
+    {
+        return TryCatch<String>([&]() -> Return<String> {
+            auto resource = suil::catstr(BATCH_STATUSES, "?id=", batchId, "&wait=", wait);
+            auto resp = http::cli::get(mSession, resource);
+
+            auto body = resp.str();
+            if (resp.status() != http::Ok) {
+                return http::HttpError{resp.status(), body};
+            }
+
+            auto res = json::Object::decode(body);
+            auto status = (String) res("data")(0)("status");
+            if (!status) {
+                return http::HttpError{http::Unknown, "status not found"};
+            }
+
+            return {status.dup()};
+        });
+    }
+
+    bool RestApi::waitForStatus(const String& batchId, uint64 wait, std::function<bool(const String&)> checker)
+    {
+        if (checker == nullptr or batchId.empty() or wait == 0) {
+            serror("waitForStatus invalid parameters");
+            return false;
+        }
+
+        auto resource = suil::catstr(BATCH_STATUSES, "?id=", batchId, "&wait=", wait);
+        int64_t until = Deadline{int64_t(wait)};
+        auto now = mnow();
+        while (now < until) {
+            auto resp = http::cli::get(mSession, resource);
+
+            auto body = resp.str();
+            if (resp.status() != http::Ok) {
+                serror("retrieving batch status failed: " PRIs " - " PRIs,
+                       _PRIs(http::toString(resp.status())),
+                       _PRIs(body));
+                return false;
+            }
+            auto res = json::Object::decode(body);
+            auto status = (String) res("data")(0)("status");
+            if (checker(status)) {
+                return true;
+            }
+            now = mnow();
+        }
+
+        return false;
+    }
+
+}

--- a/libs/sawtooth/src/stream.cpp
+++ b/libs/sawtooth/src/stream.cpp
@@ -1,0 +1,65 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include <suil/base/buffer.hpp>
+
+#include "suil/sawtooth/stream.hpp"
+
+namespace suil::saw {
+
+    uint32_t Stream::CorrelationCounter = 0;
+
+    Stream::Stream(net::zmq::Context &ctx, suil::UnorderedMap<OnAirMessage::Ptr> &msgs)
+        : mOnAirMsgs{msgs},
+          mSocket{ctx}
+    {}
+
+    Stream::Stream(Stream&& other) noexcept
+            : mOnAirMsgs(other.mOnAirMsgs),
+              mSocket(std::move(other.mSocket))
+    {}
+
+    Stream& Stream::operator=(Stream &&other) noexcept
+    {
+        Ego.mOnAirMsgs = other.mOnAirMsgs;
+        Ego.mSocket = std::move(other.mSocket);
+        return Ego;
+    }
+
+    OnAirMessage::Ptr Stream::asyncSend(Message::Type type, const suil::Data &data)
+    {
+        auto correlationId = Ego.getCorrelationId();
+        auto onAir = OnAirMessage::mkshared(std::move(correlationId));
+        mOnAirMsgs[onAir->id().peek()] = onAir;
+        Ego.send(type, data, onAir->id());
+        return onAir;
+    }
+
+    void Stream::send(Message::Type type, const suil::Data &data, const suil::String &correlationId)
+    {
+        if (!Ego.mConnected) {
+            if (!Ego.mSocket.connect("inproc://send_queue")) {
+                throw StreamError("Failed to connect to send queue: ", zmq_strerror(zmq_errno()));
+            }
+            Ego.mConnected = true;
+        }
+
+        ::sawtooth::protos::Message msg;
+        msg.set_message_type(type);
+        msg.set_correlation_id(correlationId.data(), correlationId.size());
+        msg.set_content(data.cdata(), data.size());
+        suil::Data out{msg.ByteSizeLong()};
+        msg.SerializeToArray(out.data(), static_cast<int>(out.size()));
+
+        Ego.mSocket.send(out);
+    }
+
+    suil::String Stream::getCorrelationId()
+    {
+        Buffer ob{};
+        ob << (++Ego.CorrelationCounter);
+        return String{ob};
+    }
+
+}

--- a/libs/sawtooth/src/stw/main.cpp
+++ b/libs/sawtooth/src/stw/main.cpp
@@ -1,0 +1,54 @@
+//
+// Created by Mpho Mbotho on 2021-06-11.
+//
+
+#include <suil/base/args.hpp>
+#include "stw.hpp"
+
+using suil::DefaultFormatter;
+using suil::Level;
+using suil::LogWriter;
+using suil::Syslog;
+
+using suil::args::Arg;
+using suil::args::Arguments;
+using suil::args::Command;
+using suil::args::Parser;
+
+namespace Stw = suil::saw::Stw;
+
+int main(int argc, const char* argv[])
+{
+    Stw::initLogging();
+    Parser parser("stw", "0.1.0", "An application used to create/edit a wallet file");
+
+    parser(
+        Arg{.Lf = "passwd", .Help = "The secret used to lock/unlock the wallet file",
+            .Option = false, .Required = true, .Prompt = "Enter password: ", .Hidden = true},
+        Arg{.Lf = "path", .Help = "A path to save the created wallet file (default: .sawtooth.key)", .Option = false},
+        Command("create", "Create a new wallet file initialized with a master key")
+          (Stw::cmdCreate)
+          (),
+        Command("gen", "Generate and add a new key to the given wallet file")
+          ({.Lf = "name", .Help = "The name of the key to generate", .Option = false, .Required = true})
+          (Stw::cmdGenerate)
+          (),
+        Command("get", "Get a key saved on the given wallet file")
+          ({.Lf = "name", .Help = "The name of the key to retrieve", .Option = false})
+          (Stw::cmdGet)
+          (),
+        Command("list", "List all the keys saved in the current wallet")
+          (Stw::cmdList)
+          ()
+    );
+
+    try {
+        Arguments args{argv, argc};
+        parser.parse(args);
+        parser.handle();
+    }
+    catch (...) {
+        fprintf(stderr, "%s\n", suil::Exception::fromCurrent().what());
+        return EXIT_FAILURE;
+    }
+}

--- a/libs/sawtooth/src/stw/stw.cpp
+++ b/libs/sawtooth/src/stw/stw.cpp
@@ -1,0 +1,97 @@
+//
+// Created by Mpho Mbotho on 2021-06-11.
+//
+
+#include "stw.hpp"
+
+namespace suil::saw::Stw {
+
+    void StwLogger::write(const char *log, size_t size, Level level, const char *tag)
+    {
+        static Syslog sSysLog{"suil-stw"};
+        switch (level) {
+            case Level::INFO:
+            case Level::NOTICE:
+                printf("%*s", (int)size, log);
+                break;
+            case Level::ERROR:
+            case Level::CRITICAL:
+            case Level::WARNING:
+            case Level::DEBUG:
+            case Level::TRACE:
+                sSysLog.write(log, size, level, nullptr);
+                break;
+            default:
+                break;
+        }
+    }
+
+    void initLogging()
+    {
+        suil::setup(
+            opt(writer, std::make_shared<StwLogger>()),
+            opt(format, [&](char *out, Level l, const char *tag, const char *fmt, va_list args) {
+                switch (l) {
+                    case Level::DEBUG:
+                    case Level::TRACE:
+                    case Level::ERROR:
+                    case Level::CRITICAL:
+                    case Level::WARNING:
+                        return DefaultFormatter()(out, l, tag, fmt, args);
+                    default: {
+                        int wr = vsnprintf(out, SUIL_LOG_BUFFER_SIZE, fmt, args);
+                        out[wr++] = '\n';
+                        out[wr]   = '\0';
+                        return (size_t) wr;
+                    }
+                }
+            }));
+    }
+
+    void cmdCreate(args::Command& cmd)
+    {
+        String path = cmd.value("path", ".sawtooth.key"_str);
+        String passwd = cmd["passwd"];
+
+        auto wall = Client::Wallet::create(path, passwd);
+        wall.save();
+    }
+
+    void cmdGenerate(args::Command& cmd)
+    {
+        String path = cmd.value("path", ".sawtooth.key"_str);
+        String passwd = cmd["passwd"];
+        String name = cmd["name"];
+
+        auto wall = Client::Wallet::open(path, passwd);
+        wall.generate(name);
+        wall.save();
+    }
+
+    void cmdGet(args::Command& cmd)
+    {
+        String path = cmd.value("path", ".sawtooth.key"_str);
+        String passwd = cmd["passwd"];
+        String name = cmd.value("name", ""_str);
+
+        auto wall = Client::Wallet::open(path, passwd);
+        const auto& key = wall.get(name);
+        if (key.empty()) {
+            serror("Key " PRIs " does not exist", _PRIs(name));
+        }
+        else {
+            sinfo(PRIs, _PRIs(key));
+        }
+    }
+
+    void cmdList(args::Command& cmd)
+    {
+        String path = cmd.value("path", ".sawtooth.key"_str);
+        String passwd = cmd["passwd"];
+        auto wall = Client::Wallet::open(path, passwd);
+        const auto& schema = wall.schema();
+        for (const auto& key: schema.Keys) {
+            sinfo(PRIs, _PRIs(key.Name));
+        }
+    }
+}

--- a/libs/sawtooth/src/stw/stw.hpp
+++ b/libs/sawtooth/src/stw/stw.hpp
@@ -1,0 +1,23 @@
+//
+// Created by Mpho Mbotho on 2021-06-11.
+//
+
+#pragma once
+
+#include <suil/base/args.hpp>
+#include <suil/sawtooth/wallet.hpp>
+
+namespace suil::saw::Stw {
+
+    class StwLogger : public LogWriter {
+    public:
+        void write(const char *log, size_t size, Level level, const char *tag) override;
+    };
+
+    void initLogging();
+
+    void cmdCreate(args::Command& cmd);
+    void cmdGenerate(args::Command& cmd);
+    void cmdGet(args::Command& cmd);
+    void cmdList(args::Command& cmd);
+}

--- a/libs/sawtooth/src/tp.cpp
+++ b/libs/sawtooth/src/tp.cpp
@@ -1,0 +1,207 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include "suil/sawtooth/tp.hpp"
+
+#include <suil/base/syson.hpp>
+
+namespace sp {
+    using sawtooth::protos::Message;
+    using sawtooth::protos::TransactionHeader;
+    using sawtooth::protos::TpRegisterRequest;
+    using sawtooth::protos::TpRegisterResponse;
+    using sawtooth::protos::TpUnregisterRequest;
+    using sawtooth::protos::TpUnregisterResponse;
+    using sawtooth::protos::TpProcessResponse;
+    using sawtooth::protos::TpProcessRequest;
+}
+
+namespace pl {
+    using namespace std::placeholders;
+}
+
+namespace suil::saw {
+
+    TransactionProcessor::TransactionProcessor(suil::String &&connString)
+        : mConnString(connString.dup()),
+          mDispatcher{mContext},
+          mRespStream{mDispatcher.createStream()},
+          mConnMonitor{mContext}
+    {}
+
+    void TransactionProcessor::registerAll()
+    {
+        for(const auto& [fn, handler]: Ego.mHandlers) {
+            idebug("registerAll - registering handler %s", fn());
+            auto versions = handler->getVersions();
+            for(const auto& version: versions) {
+                idebug("registerAll - register handler {name: %s, version: %s}", fn(), version());
+                sp::TpRegisterRequest req;
+                sp::TpRegisterResponse resp;
+                setValue(req, &sp::TpRegisterRequest::set_family, fn);
+                setValue(req, &sp::TpRegisterRequest::set_version, version);
+                setValue(req, &sp::TpRegisterRequest::set_protocol_version, uint32(FeatureVersion::FeatureUnused));
+                setValue(req, &sp::TpRegisterRequest::set_max_occupancy, handler->getMaxOccupancy());
+
+                for (const auto& ns: handler->getNamespaces()) {
+                    setValue(req, &sp::TpRegisterRequest::add_namespaces, ns);
+                }
+
+                setValue(req, &sp::TpRegisterRequest::set_request_header_style, Ego.mHeaderStyle);
+
+                auto future = Ego.mRespStream.asyncSend(sp::Message::TP_REGISTER_REQUEST, req);
+                future->getMessage(resp, sp::Message::TP_REGISTER_RESPONSE);
+                if (resp.status() != sp::TpRegisterResponse::OK) {
+                    throw TransactionProcessorError("failed to register handler {name: ",
+                                            fn, ", version: ", version, "}");
+                }
+                idebug("registerAll - handler successfully registered {protocol: %u}", resp.protocol_version());
+            }
+        }
+    }
+
+    void TransactionProcessor::unRegisterAll()
+    {
+        sp::TpUnregisterRequest req;
+        sp::TpUnregisterResponse resp;
+
+        auto future = Ego.mRespStream.asyncSend(sp::Message::TP_UNREGISTER_REQUEST, req);
+        future->getMessage(resp, sp::Message::TP_UNREGISTER_RESPONSE);
+
+        if (resp.status() != sp::TpUnregisterResponse::OK) {
+            ierror("TpUnregisterRequest failed: ", resp.status());
+        }
+        else {
+            idebug("TpUnregisterRequest ok");
+        }
+    }
+
+    void TransactionProcessor::handleRequest(const suil::Data &msg, const suil::String &cid)
+    {
+        sp::TpProcessRequest req;
+        sp::TpProcessResponse resp;
+        try {
+            req.ParseFromArray(msg.cdata(), static_cast<int>(msg.size()));
+            sp::TransactionHeader* txnHeader{req.release_header()};
+            suil::String fn{txnHeader->family_name()};
+            auto it = Ego.mHandlers.find(fn);
+            if (it != Ego.mHandlers.end()) {
+                try {
+                    Transaction txn(TransactionHeader{txnHeader}, req.payload(), req.signature());
+                    // WORK AROUND, ignore work around noop transaction
+                    GlobalState gs{mDispatcher.createStream(), String{req.context_id()}.dup()};
+                    auto applicator = it->second->getProcessor(std::move(txn), std::move(gs));
+                    try {
+                        applicator->apply();
+                        resp.set_status(sp::TpProcessResponse::OK);
+                    }
+                    catch (InvalidTransaction& ex) {
+                        ierror("InvalidTransaction error: %s", ex.what());
+                        resp.set_status(sp::TpProcessResponse::INVALID_TRANSACTION);
+                    }
+                    catch (...) {
+                        auto ex = Exception::fromCurrent();
+                        ierror("Transaction apply error: %s", ex.what());
+                        resp.set_status(sp::TpProcessResponse::INTERNAL_ERROR);
+                    }
+                }
+                catch (...) {
+                    auto ex = Exception::fromCurrent();
+                    ierror("Handle request error: %s", ex.what());
+                    resp.set_status(sp::TpProcessResponse::INTERNAL_ERROR);
+                }
+            }
+            else {
+                resp.set_status(sp::TpProcessResponse::INVALID_TRANSACTION);
+            }
+        }
+        catch (...) {
+            auto ex = Exception::fromCurrent();
+            ierror("Transaction process error: %s", ex.what());
+            resp.set_status(sp::TpProcessResponse::INTERNAL_ERROR);
+        }
+
+        Ego.mRespStream.sendResponse(sp::Message::TP_PROCESS_RESPONSE, resp, cid);
+    }
+
+    void TransactionProcessor::initConnectionMonitor()
+    {
+        Ego.mConnMonitor.onEvent += [&](int16 ev, int32 value, const String& addr) {
+            itrace("connectionMonitor received events %02X", ev);
+            if (ev & ZMQ_EVENT_CONNECTED) {
+                idebug("server connected event");
+                if (!Ego.mIsSeverConnected) {
+                    Ego.registerAll();
+                }
+                Ego.mIsSeverConnected = true;
+            }
+            else if (ev & ZMQ_EVENT_DISCONNECTED) {
+                idebug("server disconnected event");
+                Ego.mIsSeverConnected = false;
+            }
+            else {
+                idebug("connectionMonitor ignoring connection events %02X", ev);
+            }
+        };
+    }
+
+    void TransactionProcessor::run()
+    {
+        Once sOnceExit;
+        On({SIGNAL_TERM, SIGNAL_QUIT, SIGNAL_INT},
+           [&](auto p1, auto p2, auto p3) { handleExitSignal(p1, p2, p3); },
+           sOnceExit);
+
+        try {
+            net::zmq::DealerSocket sock(Ego.mContext);
+            sock.connect("inproc://request_queue");
+            Ego.mDispatcher.connect(Ego.mConnString);
+            Ego.mConnMonitor.start(
+                    Ego.mDispatcher.mServerSock,
+                    Dispatcher::SERVER_MONITOR_ENDPOINT, ZMQ_EVENT_CONNECTED|ZMQ_EVENT_DISCONNECTED);
+
+            Ego.mRunning = true;
+            Ego.initConnectionMonitor();
+
+            while (Ego.mRunning) {
+                net::zmq::Message msg;
+                if (!sock.receive(msg) || msg.empty() || msg.back().empty()) {
+                    continue;
+                }
+
+                sp::Message validatorMsg;
+                auto& frame = msg.back();
+                validatorMsg.ParseFromArray(frame.data(), static_cast<int>(frame.size()));
+
+                switch (validatorMsg.message_type()) {
+                    case sp::Message::TP_PROCESS_REQUEST: {
+                        Ego.handleRequest(fromStdString(validatorMsg.content()), String{validatorMsg.correlation_id()});
+                        break;
+                    }
+                    default: {
+                        idebug("Unknown message in transaction processor: %08X", validatorMsg.message_type());
+                        break;
+                    }
+                }
+            }
+        }
+        catch (...) {
+            auto ex = Exception::fromCurrent();
+            ierror("Unexpected error while running TP: %s", ex.what());
+        }
+
+        idebug("TP done, unregistering");
+        Ego.unRegisterAll();
+        Ego.mDispatcher.exit();
+    }
+
+    void TransactionProcessor::handleExitSignal(int sig, siginfo_t* /*info*/, void* /*ctx*/)
+    {
+        idebug("transaction processor received exit signal %d", sig);
+        if (Ego.mIsSeverConnected) {
+            Ego.unRegisterAll();
+        }
+    }
+
+}

--- a/libs/sawtooth/src/transaction.cpp
+++ b/libs/sawtooth/src/transaction.cpp
@@ -1,0 +1,116 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include <suil/sawtooth/transaction.hpp>
+#include <suil/base/string.hpp>
+
+namespace suil::saw {
+
+    TransactionHeader::TransactionHeader(sawtooth::protos::TransactionHeader *proto)
+            : mHeader(proto)
+    {}
+
+    TransactionHeader::TransactionHeader(TransactionHeader &&other) noexcept
+        : mHeader(other.mHeader)
+    {
+        other.mHeader = nullptr;
+    }
+
+    TransactionHeader& TransactionHeader::operator=(TransactionHeader &&other) noexcept
+    {
+        if (this != &other) {
+            Ego.mHeader = other.mHeader;
+            other.mHeader = nullptr;
+        }
+        return Ego;
+    }
+
+    TransactionHeader::~TransactionHeader() {
+        if (mHeader) {
+            delete mHeader;
+            mHeader = nullptr;
+        }
+    }
+
+    int TransactionHeader::getCount(TransactionHeader::Field field) const {
+        switch (field) {
+            case TransactionHeader::Field::StringDependencies:
+                return mHeader->dependencies_size();
+            case Field::Inputs:
+                return mHeader->inputs_size();
+            case Field::Outputs:
+                return mHeader->outputs_size();
+            case Field::Nonce:
+            case Field::FamilyName:
+            case Field::FamilyVersion:
+            case Field::PayloadSha512:
+            case Field::BatcherPublicKey:
+            case Field::SignerPublicKey:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+
+    suil::Data TransactionHeader::getValue(TransactionHeader::Field field, int index) const
+    {
+        switch (field) {
+            case TransactionHeader::Field::StringDependencies:
+                return fromStdString(mHeader->dependencies(index));
+            case Field::Inputs:
+                return fromStdString(mHeader->inputs(index));
+            case Field::Outputs:
+                return fromStdString(mHeader->outputs(index));
+            case Field::Nonce:
+                return fromStdString(mHeader->nonce());
+            case Field::FamilyName:
+                return fromStdString(mHeader->family_name());
+            case Field::FamilyVersion:
+                return fromStdString(mHeader->family_version());
+            case Field::PayloadSha512:
+                return fromStdString(mHeader->payload_sha512());
+            case Field::BatcherPublicKey:
+                return fromStdString(mHeader->batcher_public_key());
+            case Field::SignerPublicKey:
+                return fromStdString(mHeader->signer_public_key());
+            default:
+                return suil::Data{};
+        }
+    }
+
+    Transaction::Transaction(TransactionHeader&& header, std::string payload, std::string signature)
+        : mHeader(std::move(header)),
+          mPayload(std::move(payload)),
+          mSignature(std::move(signature))
+    {}
+
+    Transaction::Transaction(Transaction&& other)
+        : mHeader(std::move(other.mHeader)),
+          mPayload(std::move(other.mPayload)),
+          mSignature(std::move(other.mSignature))
+    {}
+
+    Transaction& Transaction::operator=(Transaction&& other)
+    {
+        if (this != &other) {
+            mHeader = std::move(other.mHeader);
+            mPayload = std::move(other.mPayload);
+            mSignature = std::move(other.mSignature);
+        }
+        return Ego;
+    }
+
+    const String NOOP{"84e4cee5-48f0-4af3-a60b-ed85f9401197"};
+
+    Data getNoopTransaction()
+    {
+        return Data(NOOP.data(), NOOP.size(), false);
+    }
+
+    bool isNoopTransaction(const Transaction& txn)
+    {
+        return txn.payload() == Data{NOOP.data(), NOOP.size(), false};
+    }
+
+}

--- a/libs/sawtooth/src/wallet.cpp
+++ b/libs/sawtooth/src/wallet.cpp
@@ -1,0 +1,118 @@
+//
+// Created by Mpho Mbotho on 2021-06-04.
+//
+
+#include "suil/sawtooth/wallet.hpp"
+
+#include <suil/base/crypto.hpp>
+#include <suil/base/encryption.hpp>
+#include <suil/base/file.hpp>
+#include <suil/base/wire.hpp>
+
+namespace suil::saw::Client {
+
+    static const String EMPTY{nullptr};
+
+    Wallet::Wallet(String&& path, String&& secret)
+        : mPath(std::move(path)),
+          mSecret(std::move(secret))
+    {}
+
+    Wallet::~Wallet() {
+        Ego.save();
+    }
+
+    Wallet Wallet::open(const String &path, const String& secret)
+    {
+        if (!fs::exists(path())) {
+            throw WalletError("Wallet '", path, "' not found");
+        }
+        auto encrypted = fs::readall(path());
+        if (encrypted.empty()) {
+            throw WalletError("Wallet '", path, "' does not contain a valid key");
+        }
+
+        auto decrypted = suil::AES_Decrypt(secret, encrypted);
+        if (decrypted.empty()) {
+            throw WalletError("Unlocking wallet failed, check wallet secret");
+        }
+        try {
+            Wallet w(path.dup(), secret.dup());
+            suil::HeapBoard hb(decrypted);
+            hb >> w.mData;
+            return std::move(w);
+        }
+        catch (...) {
+            throw WalletError("Invalid wallet file contents");
+        }
+    }
+
+    Wallet Wallet::create(const String& path, const String& secret)
+    {
+        if (fs::exists(path())) {
+            throw WalletError("Wallet '", path, "' already exist");
+        }
+        Wallet w(path.dup(), secret.dup());
+        auto key = crypto::ECKey::generate();
+        w.mData.MasterKey = key.getPublicKey().toString();
+        w.mDirty = true;
+        return w;
+    }
+
+    const String& Wallet::get(const suil::String &name) const
+    {
+        if (name.empty()) {
+            return defaultKey();
+        }
+
+        auto lowerName = name.dup();
+        lowerName.tolower();
+        for (const auto& key : mData.Keys) {
+            if (key.Name == lowerName) {
+                return key.Key;
+            }
+        }
+        return EMPTY;
+    }
+
+    const String& Wallet::generate(const suil::String &name)
+    {
+        auto lowerName = name.dup();
+        lowerName.tolower();
+
+        for (const auto& key : mData.Keys) {
+            if (key.Name == lowerName) {
+                throw WalletError("A key with name '", name, "' already exists in wallet");
+            }
+        }
+        auto key = crypto::ECKey::generate();
+        Ego.mData.Keys.emplace_back(std::move(lowerName), key.getPublicKey().toString());
+        Ego.mDirty = true;
+        return Ego.mData.Keys.back().Key;
+    }
+
+
+    const String& Wallet::defaultKey() const
+    {
+        return Ego.mData.MasterKey;
+    }
+
+    void Wallet::save()
+    {
+        if (mDirty) {
+            mDirty = false;
+            HeapBoard hb(1024);
+            hb << Ego.mData;
+            auto raw = hb.raw();
+            auto encrypted = suil::AES_Encrypt(Ego.mSecret, raw);
+            if (encrypted.empty()) {
+                throw WalletError("Encrypting wallet file failed");
+            }
+            if (fs::exists(Ego.mPath())) {
+                fs::remove(Ego.mPath());
+            }
+            fs::append(Ego.mPath(), encrypted.data(), encrypted.size(), false);
+        }
+    }
+
+}

--- a/libs/sawtooth/test/main.cpp
+++ b/libs/sawtooth/test/main.cpp
@@ -1,0 +1,12 @@
+//
+// Created by Mpho Mbotho on 2020-11-17.
+//
+#define CATCH_CONFIG_RUNNER
+
+#include "catch2/catch.hpp"
+
+int main(int argc, const char *argv[])
+{
+    int result = Catch::Session().run(argc, argv);
+    return (result < 0xff ? result: 0xff);
+}


### PR DESCRIPTION
#### Overview
Adding support for a sawtooth client library. The library can be used to developer sawtooth transaction processor's in `C++`.

- Support for interacting with REST API via `SuilHttpClient` library
- Included an example `Int-Key` transaction processor and client
- Support for event subscription through ZMQ