### PR TITLE
Update postgres SQL database statement to parse to a tuple

### DIFF
--- a/libs/database/examples/postgres/main.cpp
+++ b/libs/database/examples/postgres/main.cpp
@@ -81,9 +81,11 @@ void start()
             auto users = orm.getAll();
             verify((users.size() == 2), "2 users should have been read from database");
             uptr = reinterpret_cast<std::uintptr_t>(&conn);
-            auto results = conn("SELECT Username,Age FROM users WHERE Id=$")(0);
-            std::tuple<std::string_view,int> res;
-            results >> res;
+            auto results = conn("SELECT Username,Age FROM users WHERE Id=$1");
+            std::tuple<std::string_view, int> res;
+            verify((results(users[0].id) >> res), "Query should be successful and result should be decoded");
+            verify(users[0].Username == get<0>(res), "Decoding to tuple expected to be successful");
+            verify(users[0].Age == get<1>(res), "Decoding to tuple expected to be successful");
         }
         yield();
         {

--- a/libs/database/include/suil/db/pgsql.hpp
+++ b/libs/database/include/suil/db/pgsql.hpp
@@ -516,7 +516,7 @@ namespace suil::db {
             if (results.empty()) return false;
 
             int col{0};
-            bool status{false};
+            bool status{true};
 
             iod::tuple_map(tup, [&](auto& e) {
                 using T = std::remove_cvref_t<decltype(e)>;
@@ -527,10 +527,7 @@ namespace suil::db {
                          std::is_same_v<T, std::string> or
                          std::is_same_v<T, json::Object>),
                         "Only literal types or json::Object can be present in the tuple");
-                if (!status) {
-                    return;
-                }
-                status = results.read(e, col++);
+                status = status && results.read(e, col++);
             });
             results.next();
 
@@ -699,7 +696,6 @@ namespace suil::db {
             bin  = 0;
             return b.release();
         }
-
 
         struct pgsql_result {
             using result_q_t = std::deque<PGresult*>;


### PR DESCRIPTION
This update will allow parsing results to an `std::tuple`, this would allow raw query statements to be easily parsed to a tuple
```c++
auto query = conn("SELECT Username,Age FROM Users WHERE Id=$1");
std::tuple<std::string_view,int> results;
if (query(0) >> results) {
    std::cout << "Username: " << get<0>(results) << ", Age: " << get<1>(results) << "\n";
}
```
Note that this can simple be achieved by using an `sio` object
```c++
using Row = decltype(iod::D(prop(Username, std::string_view), prop(Age, int)));
auto query = conn("SELECT Username,Age FROM Users WHERE Id=$1");
Row row{};
if (query(0) >> row) {
    std::cout << "Username: " <<row.Username << ", Age: " << row.Age << "\n";
}
```